### PR TITLE
Generation of shader input/output declarations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,5 @@ posh-macros = { path = "macros", version = "*" }
 [dev-dependencies]
 posh = { version = "*", path = ".", features = ["nalgebra"] }
 
-[dependencies.uuid]
-version = "1.1.0"
-features = ["v4"]
-
 [workspace]
 members = ["macros", "glace"]

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -5,7 +5,7 @@ use posh::{
 };
 
 #[derive(Expose)]
-#[expose(UniformBlock, Vertex)]
+#[expose(UniformBlock)]
 struct Transforms {
     world_to_view: Vector3<f32>,
     view_to_clip: Vector3<f32>,

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,6 +1,9 @@
+use std::collections::BTreeSet;
+
 use nalgebra::Vector3;
 use posh::{
-    shader::{FArg, FOut, Shader, VArg, VOut},
+    lang::{defs::collect_vars, show::show_defs},
+    shader::{show::show_shader, ErasedVStage, FArg, FOut, Shader, VArg, VOut},
     Expose, Rep, Sampler2,
 };
 
@@ -51,9 +54,9 @@ fn vertex_stage(res: Rep<Resources>, arg: VArg<Vertex>) -> VOut<Interps> {
         color: posh::vec3(255.0, 0.0, 0.0),
         normal: res.two.model_to_view * arg.attrs.normal,
     };
-    let position = res.one.view_to_clip * res.one.model_to_view * arg.attrs.position;
+    let pos = res.one.view_to_clip * res.one.model_to_view * arg.attrs.position;
 
-    VOut { interps, position }
+    VOut { interps, pos }
 }
 
 fn vertex_stage2(res: Rep<Resources>, arg: VArg<(Vertex, Instance)>) -> VOut<Interps> {
@@ -63,9 +66,9 @@ fn vertex_stage2(res: Rep<Resources>, arg: VArg<(Vertex, Instance)>) -> VOut<Int
         color: instance.color,
         normal: res.one.model_to_view * vertex.normal,
     };
-    let position = res.one.model_to_view * vertex.position;
+    let pos = res.one.model_to_view * vertex.position;
 
-    VOut { interps, position }
+    VOut { interps, pos }
 }
 
 fn fragment_stage(_: Rep<Resources>, arg: FArg<Interps>) -> FOut<Frag> {
@@ -94,5 +97,7 @@ fn main() {
         shader: Shader::new(vertex_stage2, fragment_stage),
     };
 
-    let shaduer: Shader<Resources, _, _> = Shader::new(vertex_stage2, fragment_stage);
+    let shader: Shader<Resources, _, _> = Shader::new(vertex_stage2, fragment_stage);
+
+    println!("{}", show_shader(shader.erased()))
 }

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -63,7 +63,7 @@ fn vertex_stage(res: Rep<Resources>, arg: VArg<Vertex>) -> VOut<Interps> {
 }
 
 fn vertex_stage_instanced(res: Rep<Resources>, arg: VArg<(Vertex, Instance)>) -> VOut<Interps> {
-    let (vertex, instance) = arg.attrs;
+    let (vertex, instance) = posh::var(arg.attrs);
 
     let interps = Rep::<Interps> {
         color: instance.color,

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -12,10 +12,17 @@ struct Transforms {
 }
 
 #[derive(Expose)]
+#[expose(UniformBlock)]
+struct Settings {
+    light: bool,
+}
+
+#[derive(Expose)]
 #[expose(Resources)]
 struct Resources {
     camera: Transforms,
     shadow: Transforms,
+    settings: Settings,
 }
 
 #[derive(Expose)]
@@ -63,7 +70,7 @@ fn vertex_stage(res: Rep<Resources>, arg: VArg<Vertex>) -> VOut<Interps> {
 }
 
 fn vertex_stage_instanced(res: Rep<Resources>, arg: VArg<(Vertex, Instance)>) -> VOut<Interps> {
-    let (vertex, instance) = posh::var(arg.attrs);
+    let (vertex, instance) = arg.attrs;
 
     let interps = Rep::<Interps> {
         color: instance.color,
@@ -74,21 +81,14 @@ fn vertex_stage_instanced(res: Rep<Resources>, arg: VArg<(Vertex, Instance)>) ->
     VOut { interps, pos }
 }
 
-fn fragment_stage(_: Rep<Resources>, arg: FArg<Interps>) -> FOut<Frag> {
+fn fragment_stage(res: Rep<Resources>, arg: FArg<Interps>) -> FOut<Frag> {
+    let color = posh::var(res.settings.light.branch(2.0, 3.0));
     let frag = posh::var(Rep::<Frag> {
-        color: arg.interps.color,
+        color: arg.interps.color * color,
         normal: arg.interps.normal,
     });
 
     FOut::frag(frag)
-}
-
-struct MyShader {
-    shader: Shader<Resources, Vertex, Frag>,
-}
-
-struct MyShader2 {
-    shader: Shader<Resources, (Vertex, Instance), Frag>,
 }
 
 fn main() {

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,10 +1,7 @@
-use std::collections::BTreeSet;
-
 use nalgebra::Vector3;
 use posh::{
-    lang::{defs::collect_vars, show::show_defs},
-    shader::{show::show_shader, ErasedVStage, FArg, FOut, Shader, VArg, VOut},
-    Expose, Rep, Sampler2,
+    shader::{show::show_shader, FArg, FOut, Shader, VArg, VOut},
+    Expose, Rep,
 };
 
 #[derive(Expose)]

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -1,8 +1,8 @@
 use nalgebra::Vector3;
 use posh::{
     expose::compile::compile1,
-    lang::{defs::Defs, show::show_defs, Ident},
-    rep, Expose, FuncArg, IntoRep, Rep, ScalarType,
+    lang::{defs::Defs, show::show_defs},
+    rep, Expose, IntoRep, Rep, ScalarType,
 };
 
 #[derive(Expose)]

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -1,5 +1,9 @@
 use nalgebra::Vector3;
-use posh::{lang::Ident, rep, Expose, FuncArg, IntoRep, Rep, ScalarType};
+use posh::{
+    expose::compile::compile1,
+    lang::{defs::Defs, show::show_defs, Ident},
+    rep, Expose, FuncArg, IntoRep, Rep, ScalarType,
+};
 
 #[derive(Expose)]
 pub struct Helper {
@@ -43,12 +47,7 @@ fn vertex(vertex: Rep<test::Vertex>) -> Rep<test::Vertex> {
 }
 
 pub fn main() {
-    let result = vertex(Rep::<test::Vertex>::from_ident(Ident::new("foo")));
-    println!("{:#?}", result.expr());
+    let func_def = compile1(vertex).unwrap();
 
-    if let posh::lang::Expr::Call(expr) = result.expr() {
-        if let posh::lang::Func::UserDefined(func) = expr.func {
-            println!("{}", posh::lang::show::show_user_defined_funcs(&func));
-        }
-    }
+    println!("{}", show_defs(&Defs::from_func_def(&func_def)));
 }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -4,13 +4,13 @@ use posh::{
 };
 
 #[posh::def]
-fn triplet<T: ScalarType>(t: Rep<T>) -> posh::Vec3<T> {
-    posh::vec3(t, t, t)
+fn triplet<T: ScalarType>(t: Rep<T>) -> (posh::Vec3<T>, Rep<u32>) {
+    (posh::vec3(t, t, t), 32.into())
 }
 
 #[posh::def]
-fn foo(x: Rep<f32>, y: Rep<f32>) -> Rep<f32> {
-    let z = posh::var(x * y);
+fn foo(x: Rep<f32>, y: Rep<f32>, z: (Rep<f32>, Rep<f32>)) -> Rep<f32> {
+    let z = posh::var(x * y - z.1);
     let w = posh::var(1.0 + y + x + 1.0);
 
     z.eq(w).and(w.eq(1.0)).branch(3.0 * z * 2.0, 1.0)
@@ -18,16 +18,20 @@ fn foo(x: Rep<f32>, y: Rep<f32>) -> Rep<f32> {
 
 #[posh::def]
 fn bar(x: Rep<f32>) -> Rep<f32> {
-    let ints = triplet::<u32>(1.into());
-    let floats = triplet(2.0.into());
+    let ints = triplet::<u32>(1.into()).0;
+    let floats = triplet(2.0.into()).0;
 
-    floats.x * ints.y.eq(2u32).branch(-1.0, foo(x, x))
+    floats.x * ints.y.eq(2u32).branch(-1.0, foo(x, x, (x, x)))
 }
 
 #[posh::def]
 fn texture_thing(sampler: posh::Sampler2) -> posh::Vec4<f32> {
     let c = posh::var(sampler.load(vec2(1.0, bar(3.0.into()))));
-    sampler.load(vec2(2.0 * c.y, foo(1.0.into(), 2.0.into())).normalize() / 5.0)
+
+    let dum = posh::var(foo(1.0.into(), 2.0.into(), (c.x, c.y)));
+    let tex_coord = vec2(2.0 * c.y, dum).normalize() / 5.0;
+
+    sampler.load(tex_coord)
 }
 
 fn main() {

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -10,7 +10,7 @@ fn foo(x: Rep<f32>, y: Rep<f32>) -> Rep<f32> {
     let z = posh::var(x * y);
     let w = posh::var(1.0 + y + x + 1.0);
 
-    z.eq(w).and(w.eq(1.0)).ternary(3.0 * z * 2.0, 1.0)
+    z.eq(w).and(w.eq(1.0)).branch(3.0 * z * 2.0, 1.0)
 }
 
 #[posh::def]
@@ -18,7 +18,7 @@ fn bar(x: Rep<f32>) -> Rep<f32> {
     let ints = triplet::<u32>(1.into());
     let floats = triplet(2.0.into());
 
-    floats.x * ints.y.eq(2u32).ternary(-1.0, foo(x, x))
+    floats.x * ints.y.eq(2u32).branch(-1.0, foo(x, x))
 }
 
 #[posh::def]

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,4 +1,7 @@
-use posh::{lang::Ident, vec2, FuncArg, GenValue, Rep, ScalarType};
+use posh::{
+    expose::compile::compile1, lang::defs::Defs, lang::show::show_defs, vec2, GenValue, Rep,
+    ScalarType,
+};
 
 #[posh::def]
 fn triplet<T: ScalarType>(t: Rep<T>) -> posh::Vec3<T> {
@@ -28,12 +31,7 @@ fn texture_thing(sampler: posh::Sampler2) -> posh::Vec4<f32> {
 }
 
 fn main() {
-    let sampler = posh::Sampler2::from_ident(Ident::new("bla")); // hack
-    let result = texture_thing(sampler);
+    let func_def = compile1(texture_thing).unwrap();
 
-    if let posh::lang::Expr::Call(expr) = result.expr() {
-        if let posh::lang::Func::UserDefined(func) = expr.func {
-            println!("{}", posh::lang::show::show_user_defined_funcs(&func));
-        }
-    }
+    println!("{}", show_defs(&Defs::from_func_def(&func_def)));
 }

--- a/macros/src/def.rs
+++ b/macros/src/def.rs
@@ -1,7 +1,5 @@
-use std::iter;
-
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{quote, ToTokens};
 use syn::{
     parse_quote, parse_quote_spanned, spanned::Spanned, Block, Error, Expr, FnArg, Ident, ItemFn,
     Pat, Result, ReturnType, Signature, Stmt, Type,

--- a/macros/src/def.rs
+++ b/macros/src/def.rs
@@ -106,7 +106,7 @@ pub fn transform(mut item: ItemFn) -> Result<TokenStream2> {
 
             // Return a Posh expression which defines *and* calls the function.
             ::posh::expose::func_def_and_call(
-                ::posh::lang::UserDefinedFunc {
+                ::posh::lang::DefFunc {
                     ident: ::posh::lang::Ident::new(stringify!(#func_ident)),
                     params: vec![#(#param_exprs),*],
                     result: ::std::rc::Rc::new({

--- a/macros/src/def.rs
+++ b/macros/src/def.rs
@@ -5,7 +5,7 @@ use syn::{
     Pat, Result, ReturnType, Signature, Stmt, Type,
 };
 
-fn inputs(sig: &Signature) -> Result<(Vec<Ident>, Vec<Box<Type>>)> {
+fn inputs(sig: &Signature) -> Result<(Vec<Ident>, Vec<Type>)> {
     let mut input_idents = Vec::new();
     let mut input_tys = Vec::new();
 
@@ -14,7 +14,7 @@ fn inputs(sig: &Signature) -> Result<(Vec<Ident>, Vec<Box<Type>>)> {
             match &*input.pat {
                 Pat::Ident(ident) => {
                     input_idents.push(ident.ident.clone());
-                    input_tys.push(input.ty.clone());
+                    input_tys.push(*input.ty.clone());
                 }
                 _ => {
                     return Err(Error::new_spanned(
@@ -41,7 +41,7 @@ pub fn transform(mut item: ItemFn) -> Result<TokenStream2> {
                 "posh::def: Function must return a value",
             ));
         }
-        ReturnType::Type(_, ty) => ty.clone(),
+        ReturnType::Type(_, ty) => ty,
     };
 
     let func_ident = item.sig.ident.clone();

--- a/macros/src/expose.rs
+++ b/macros/src/expose.rs
@@ -299,7 +299,8 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
                         #(::posh::FuncArg::expr(&self.#field_idents)),*
                     ];
 
-                    if let Some(common_base) = ::posh::expose::common_field_base(&args) {
+                    let common_base = ::posh::expose::common_field_base(&Self::ty(), &args);
+                    if let Some(common_base) = common_base {
                         common_base
                     } else {
                         let ty = match <Self as ::posh::FuncArg>::ty() {

--- a/macros/src/expose.rs
+++ b/macros/src/expose.rs
@@ -207,7 +207,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
         .collect();
     let field_strings: Vec<_> = field_idents.iter().map(|ident| ident.to_string()).collect();
 
-    let rep_name = Ident::new(&format!("_{}PoshRep", name), name.span());
+    let rep_name = Ident::new(&super::rep::rep_name(&name_string), name.span());
 
     let posh_struct_def = quote_spanned! {name.span()=>
         #[must_use]

--- a/macros/src/expose.rs
+++ b/macros/src/expose.rs
@@ -10,7 +10,6 @@ use syn::{
     token, Attribute, Data, DataStruct, DeriveInput, Error, Field, Fields, Generics, Ident, Result,
     Token, Type,
 };
-use uuid::Uuid;
 
 fn struct_fields(ident: &Ident, data: Data) -> Result<Vec<Field>> {
     match data {
@@ -194,9 +193,6 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
     let name_string = name.to_string();
     let vis = input.vis;
 
-    // FIXME: Using UUIDs in proc macros might break incremental compilation.
-    let uuid_string = Uuid::new_v4().to_string();
-
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let field_vis: Vec<_> = fields.iter().map(|field| &field.vis).collect();
@@ -279,12 +275,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
         quote! {
             impl #impl_generics ::posh::FuncArg for #rep_name #ty_generics #where_clause {
                 fn ty() -> ::posh::lang::Ty {
-                    let name = #name_string.to_string();
-                    let uuid = ::std::str::FromStr::from_str(#uuid_string).unwrap();
-                    let ident = ::posh::lang::Ident {
-                        name,
-                        uuid,
-                    };
+                    let ident = ::posh::lang::Ident::new(#name_string);
 
                     let fields = vec![
                         #(

--- a/macros/src/expose.rs
+++ b/macros/src/expose.rs
@@ -85,6 +85,7 @@ impl RepTrait {
 
                 quote_spanned! {field_ty.span() =>
                     impl #impl_generics #rep_name #ty_generics #where_clause {
+                        #[allow(unused)]
                         fn #method_name() {
                             #(
                                 <::posh::Rep<#field_ty> as #field_reqs>::must_impl();
@@ -294,13 +295,6 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
                 }
 
                 fn expr(&self) -> ::posh::lang::Expr {
-                    let ty = match <Self as ::posh::FuncArg>::ty() {
-                        ::posh::lang::Ty::Struct(ty) => ty,
-                        _ => unreachable!(),
-                    };
-                    let struct_func = ::posh::lang::StructFunc { ty };
-                    let func = ::posh::lang::Func::Struct(struct_func);
-
                     let args = vec![
                         #(::posh::FuncArg::expr(&self.#field_idents)),*
                     ];
@@ -308,6 +302,11 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
                     if let Some(common_base) = ::posh::expose::common_field_base(&args) {
                         common_base
                     } else {
+                        let ty = match <Self as ::posh::FuncArg>::ty() {
+                            ::posh::lang::Ty::Struct(ty) => ty,
+                            _ => unreachable!(),
+                        };
+                        let func = ::posh::lang::Func::Struct(::posh::lang::StructFunc { ty });
                         let call_expr = ::posh::lang::CallExpr { func, args };
                         ::posh::lang::Expr::Call(call_expr)
                     }

--- a/macros/src/expose.rs
+++ b/macros/src/expose.rs
@@ -105,18 +105,23 @@ const REP_TRAITS: &[RepTrait] = &[
         field_reqs: &[],
     },
     RepTrait {
+        name: "InputFields",
+        deps: &["Fields"],
+        field_reqs: &[],
+    },
+    RepTrait {
         name: "Value",
         deps: &[],
         field_reqs: &[|| quote! { ::posh::Value }],
     },
     RepTrait {
         name: "Vertex",
-        deps: &["Value", "Fields"],
+        deps: &["Value", "InputFields"],
         field_reqs: &[|| quote! { ::posh::shader::VertexField }],
     },
     RepTrait {
         name: "Interpolants",
-        deps: &["Value", "Fields"],
+        deps: &["Value", "InputFields"],
         field_reqs: &[|| quote! { ::posh::shader::InterpolantsField }],
     },
     RepTrait {
@@ -131,7 +136,7 @@ const REP_TRAITS: &[RepTrait] = &[
     },
     RepTrait {
         name: "Resources",
-        deps: &[],
+        deps: &["InputFields"],
         field_reqs: &[|| quote! { ::posh::shader::Resources }],
     },
 ];
@@ -247,7 +252,15 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
                         ),*
                     ]
                 }
+           }
+        }
+    });
 
+    let impl_input_fields = rep_traits.get("InputFields").map(|_| {
+        quote! {
+            impl #impl_generics ::posh::shader::fields::InputFields
+                for #rep_name #ty_generics #where_clause
+            {
                 fn stage_input(prefix: &str) -> Self {
                     Self {
                         #(
@@ -398,6 +411,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
         iter::once(posh_struct_def)
             .chain(field_req_checks)
             .chain(impl_fields)
+            .chain(impl_input_fields)
             .chain(impl_value)
             .chain(impl_vertex)
             .chain(impl_interpolants)

--- a/macros/src/expose.rs
+++ b/macros/src/expose.rs
@@ -98,7 +98,7 @@ impl RepTrait {
     }
 }
 
-const REP_TRAITS: &'static [RepTrait] = &[
+const REP_TRAITS: &[RepTrait] = &[
     RepTrait {
         name: "UniformBlock",
         deps: &["Value"],
@@ -158,10 +158,7 @@ fn expose_rep_traits(attrs: Vec<Attribute>) -> Result<HashMap<&'static str, RepT
         .iter()
         .map(|ident| {
             let rep_trait = get_rep_trait(&ident.to_string()).ok_or_else(|| {
-                Error::new_spanned(
-                    ident,
-                    format!("Unhandled expose trait: {}", ident.to_string()),
-                )
+                Error::new_spanned(ident, format!("Unhandled expose trait: {}", ident))
             })?;
             Ok((rep_trait.name, rep_trait))
         })

--- a/macros/src/rep.rs
+++ b/macros/src/rep.rs
@@ -2,6 +2,10 @@ use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::ToTokens;
 use syn::{parse::Parse, spanned::Spanned, Error, Result, Type, TypePath};
 
+pub fn rep_name(name: &str) -> String {
+    format!("_{}PoshRep", name)
+}
+
 fn rep_type(ty: &mut Type) -> Result<()> {
     let span = ty.span();
 
@@ -12,7 +16,7 @@ fn rep_type(ty: &mut Type) -> Result<()> {
                 .last_mut()
                 .ok_or_else(|| Error::new(span, "posh::rep: Empty path not supported"))?;
             last_segment.ident = Ident::new(
-                &("_".to_string() + &last_segment.ident.to_string() + "PoshRep"),
+                &rep_name(&last_segment.ident.to_string()),
                 last_segment.ident.span(),
             );
             Ok(())

--- a/macros/src/rep.rs
+++ b/macros/src/rep.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::ToTokens;
-use syn::{parse::Parse, spanned::Spanned, Error, Result, Type, TypePath};
+use syn::{spanned::Spanned, Error, Result, Type, TypePath};
 
 pub fn rep_name(name: &str) -> String {
     format!("_{}PoshRep", name)

--- a/src/expose.rs
+++ b/src/expose.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 mod built_in_value;
+pub mod compile;
 mod expr_reg;
 mod gen_value;
 #[cfg(feature = "nalgebra")]

--- a/src/expose/compile.rs
+++ b/src/expose/compile.rs
@@ -1,0 +1,22 @@
+use crate::lang::{DefFunc, Expr, Func, Ident};
+
+use super::{FuncArg, Value};
+
+pub fn compile1<U, R>(f: fn(U) -> R) -> Option<DefFunc>
+where
+    U: FuncArg,
+    R: Value,
+{
+    let u = U::from_ident(Ident::new("u"));
+    let r = f(u);
+
+    if let Expr::Call(expr) = r.expr() {
+        if let Func::Def(func) = expr.func {
+            Some(func)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/src/expose/primitives.rs
+++ b/src/expose/primitives.rs
@@ -1,8 +1,7 @@
 use std::{collections::BTreeSet, rc::Rc};
 
 use crate::lang::{
-    BinaryExpr, BinaryOp, BuiltInFunc, CallExpr, Expr, FieldExpr, Func, Ident, Ty, UserDefinedFunc,
-    VarExpr,
+    BinaryExpr, BinaryOp, BuiltInFunc, CallExpr, DefFunc, Expr, FieldExpr, Func, Ident, Ty, VarExpr,
 };
 
 use super::{FuncArg, IntoRep, Trace, Value};
@@ -70,10 +69,10 @@ pub fn field<R: Value>(base: Trace, member: &str) -> R {
 }
 
 #[doc(hidden)]
-pub fn func_def_and_call<R: Value>(def: UserDefinedFunc, args: Vec<Expr>) -> R {
+pub fn func_def_and_call<R: Value>(def: DefFunc, args: Vec<Expr>) -> R {
     assert!(def.params.len() == args.len());
 
-    let func = Func::UserDefined(def);
+    let func = Func::Def(def);
     let expr = Expr::Call(CallExpr { func, args });
 
     R::from_expr(expr)

--- a/src/expose/primitives.rs
+++ b/src/expose/primitives.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeSet, rc::Rc};
 
 use crate::lang::{
-    BinaryExpr, BinaryOp, BuiltInFunc, CallExpr, Expr, FieldExpr, Func, FuncParam, Ident, Ty,
-    UserDefinedFunc, VarExpr,
+    BinaryExpr, BinaryOp, BuiltInFunc, CallExpr, Expr, FieldExpr, Func, Ident, Ty, UserDefinedFunc,
+    VarExpr,
 };
 
 use super::{FuncArg, IntoRep, Trace, Value};

--- a/src/expose/primitives.rs
+++ b/src/expose/primitives.rs
@@ -22,14 +22,16 @@ pub fn var<R: Value>(init: R) -> R {
 }
 
 #[doc(hidden)]
-pub fn common_field_base(exprs: &[Expr]) -> Option<Expr> {
+pub fn common_field_base(target_ty: &Ty, exprs: &[Expr]) -> Option<Expr> {
     exprs.first().and_then(|first_expr| {
         if let Expr::Field(first_field_expr) = first_expr {
             let mut fields = BTreeSet::new();
 
             for expr in exprs {
                 if let Expr::Field(field_expr) = expr {
-                    if field_expr.base != first_field_expr.base {
+                    if field_expr.base.ty() != *target_ty
+                        || field_expr.base != first_field_expr.base
+                    {
                         return None;
                     }
 

--- a/src/expose/scalar.rs
+++ b/src/expose/scalar.rs
@@ -7,7 +7,7 @@ use std::{
 use sealed::sealed;
 
 use crate::lang::{
-    BinaryOp, BuiltInTy, Expr, Ident, Literal, LiteralExpr, ScalarTy, TernaryExpr, Ty,
+    BinaryOp, BranchExpr, BuiltInTy, Expr, Ident, Literal, LiteralExpr, ScalarTy, Ty,
 };
 
 use super::{binary, Expose, FuncArg, IntoRep, Representative, Trace, Value};
@@ -83,7 +83,7 @@ impl Scalar<bool> {
         binary(self, BinaryOp::And, right)
     }
 
-    pub fn ternary<V: Value>(
+    pub fn branch<V: Value>(
         self,
         true_value: impl IntoRep<Rep = V>,
         false_value: impl IntoRep<Rep = V>,
@@ -92,7 +92,7 @@ impl Scalar<bool> {
         let true_expr = Rc::new(true_value.into_rep().expr());
         let false_expr = Rc::new(false_value.into_rep().expr());
 
-        let expr = Expr::Ternary(TernaryExpr {
+        let expr = Expr::Branch(BranchExpr {
             cond,
             true_expr,
             false_expr,

--- a/src/expose/tuple.rs
+++ b/src/expose/tuple.rs
@@ -1,4 +1,6 @@
-use super::{Expose, FuncArg, Rep, Representative, Value};
+use crate::lang::{CallExpr, Expr, Func, Ident, StructFunc, StructTy, Ty};
+
+use super::{common_field_base, field, Expose, FuncArg, Rep, Representative, Trace, Value};
 
 impl<U, V> Expose for (U, V)
 where
@@ -20,16 +22,30 @@ where
     U: Value,
     V: Value,
 {
-    fn ty() -> crate::lang::Ty {
-        todo!()
+    fn ty() -> Ty {
+        Ty::Struct(StructTy {
+            ident: Ident::new("Pair"),
+            fields: vec![("p0".into(), U::ty()), ("p1".into(), V::ty())],
+        })
     }
 
-    fn from_ident(ident: crate::lang::Ident) -> Self {
-        todo!()
+    fn from_ident(ident: Ident) -> Self {
+        Self::from_trace(Trace::from_ident::<Self>(ident))
     }
 
-    fn expr(&self) -> crate::lang::Expr {
-        todo!()
+    fn expr(&self) -> Expr {
+        let args = vec![self.0.expr(), self.1.expr()];
+
+        if let Some(common_base) = common_field_base(&args) {
+            common_base
+        } else {
+            let ty = match <Self as FuncArg>::ty() {
+                Ty::Struct(ty) => ty,
+                _ => unreachable!(),
+            };
+            let func = Func::Struct(StructFunc { ty });
+            Expr::Call(CallExpr { func, args })
+        }
     }
 }
 
@@ -38,7 +54,9 @@ where
     U: Value,
     V: Value,
 {
-    fn from_trace(trace: super::Trace) -> Self {
-        todo!()
+    fn from_trace(trace: Trace) -> Self {
+        assert!(trace.expr().ty() == <Self::Rep as FuncArg>::ty());
+
+        (field(trace, "p0"), field(trace, "p1"))
     }
 }

--- a/src/expose/tuple.rs
+++ b/src/expose/tuple.rs
@@ -36,7 +36,7 @@ where
     fn expr(&self) -> Expr {
         let args = vec![self.0.expr(), self.1.expr()];
 
-        if let Some(common_base) = common_field_base(&args) {
+        if let Some(common_base) = common_field_base(&Self::ty(), &args) {
             common_base
         } else {
             let ty = match <Self as FuncArg>::ty() {

--- a/src/expose/tuple.rs
+++ b/src/expose/tuple.rs
@@ -25,7 +25,7 @@ where
     fn ty() -> Ty {
         Ty::Struct(StructTy {
             ident: Ident::new("Pair"),
-            fields: vec![("p0".into(), U::ty()), ("p1".into(), V::ty())],
+            fields: vec![("x0".into(), U::ty()), ("x1".into(), V::ty())],
         })
     }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -2,8 +2,6 @@ pub mod show;
 
 use std::rc::Rc;
 
-pub use uuid::Uuid;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ScalarTy {
     F32,
@@ -36,21 +34,17 @@ pub struct StructTy {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Ident {
     pub name: String,
-    pub uuid: Uuid,
 }
 
 impl Ident {
     pub fn new(name: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            uuid: Uuid::new_v4(),
-        }
+        Self { name: name.into() }
     }
 }
 
 impl ToString for Ident {
     fn to_string(&self) -> String {
-        format!("{}_{}", self.name, &self.uuid.simple().to_string()[0..8])
+        self.name.clone()
     }
 }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,3 +1,4 @@
+pub mod defs;
 pub mod show;
 
 use std::rc::Rc;
@@ -57,7 +58,7 @@ pub struct FuncParam {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Func {
     BuiltIn(BuiltInFunc),
-    UserDefined(UserDefinedFunc),
+    Def(DefFunc),
     Struct(StructFunc),
 }
 
@@ -68,7 +69,7 @@ pub struct BuiltInFunc {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UserDefinedFunc {
+pub struct DefFunc {
     pub ident: Ident,
     pub params: Vec<FuncParam>,
     pub result: Rc<Expr>,
@@ -85,7 +86,7 @@ impl Func {
 
         match self {
             BuiltIn(BuiltInFunc { ty, .. }) => ty.clone(),
-            UserDefined(UserDefinedFunc { result, .. }) => result.ty(),
+            Def(DefFunc { result, .. }) => result.ty(),
             Struct(StructFunc { ty }) => Ty::Struct(ty.clone()),
         }
     }
@@ -95,7 +96,7 @@ impl Func {
 
         match self {
             BuiltIn(BuiltInFunc { name, .. }) => name,
-            UserDefined(UserDefinedFunc { ident, .. }) => &ident.name,
+            Def(DefFunc { ident, .. }) => &ident.name,
             Struct(StructFunc { ty, .. }) => &ty.ident.name,
         }
     }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -157,12 +157,11 @@ pub enum BinaryOp {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Expr {
     Binary(BinaryExpr),
-    Ternary(TernaryExpr),
+    Branch(BranchExpr),
     Var(VarExpr),
     Call(CallExpr),
     Literal(LiteralExpr),
     Field(FieldExpr),
-    BuiltInVar(BuiltInVarExpr),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -174,7 +173,7 @@ pub struct BinaryExpr {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TernaryExpr {
+pub struct BranchExpr {
     pub cond: Rc<Expr>,
     pub true_expr: Rc<Expr>,
     pub false_expr: Rc<Expr>,
@@ -205,19 +204,13 @@ pub struct FieldExpr {
     pub ty: Ty,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BuiltInVarExpr {
-    pub name: String,
-    pub ty: BuiltInTy,
-}
-
 impl Expr {
     pub fn ty(&self) -> Ty {
         use Expr::*;
 
         match self {
             Binary(expr) => expr.ty.clone(),
-            Ternary(expr) => {
+            Branch(expr) => {
                 assert!(expr.true_expr.ty() == expr.false_expr.ty());
                 expr.true_expr.ty()
             }
@@ -225,7 +218,6 @@ impl Expr {
             Call(expr) => expr.func.ty(),
             Literal(expr) => expr.literal.ty.clone(),
             Field(expr) => expr.ty.clone(),
-            BuiltInVar(expr) => Ty::BuiltIn(expr.ty.clone()),
         }
     }
 }

--- a/src/lang/defs.rs
+++ b/src/lang/defs.rs
@@ -1,0 +1,164 @@
+use std::collections::BTreeSet;
+
+use super::{DefFunc, Expr, Func, Ident, StructTy, Ty, VarExpr};
+
+#[derive(Debug, Clone, Default)]
+pub struct Defs {
+    pub structs: BTreeSet<StructTy>,
+    pub funcs: BTreeSet<DefFunc>,
+}
+
+impl Defs {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_expr(expr: &Expr) -> Self {
+        let mut structs = BTreeSet::new();
+        let mut funcs = BTreeSet::new();
+
+        collect_structs(expr, &mut structs);
+        collect_funcs(expr, &mut funcs);
+
+        Self { structs, funcs }
+    }
+
+    pub fn from_func_def(func: &DefFunc) -> Self {
+        let mut defs = Defs::from_expr(&func.result);
+        defs.funcs.insert(func.clone());
+
+        defs
+    }
+
+    pub fn extend(&mut self, defs: &Defs) {
+        self.structs.extend(defs.structs.clone());
+        self.funcs.extend(defs.funcs.clone());
+    }
+
+    pub fn close(&mut self) {}
+}
+
+pub fn collect_structs(expr: &Expr, structs: &mut BTreeSet<StructTy>) {
+    use Expr::*;
+
+    collect_struct_ty(&expr.ty(), structs);
+
+    match expr {
+        Binary(expr) => {
+            collect_structs(&*expr.left, structs);
+            collect_structs(&*expr.right, structs);
+        }
+        Branch(expr) => {
+            collect_structs(&*expr.cond, structs);
+            collect_structs(&*expr.true_expr, structs);
+            collect_structs(&*expr.false_expr, structs);
+        }
+        Var(expr) => {
+            if let Some(ref init) = expr.init {
+                collect_structs(init, structs);
+            }
+        }
+        Call(expr) => {
+            if let Func::Def(func) = &expr.func {
+                for param in func.params.iter() {
+                    collect_struct_ty(&param.ty, structs);
+                }
+                collect_structs(&*func.result, structs);
+            }
+
+            for arg in &expr.args {
+                collect_structs(arg, structs);
+            }
+        }
+        Literal(_) => (),
+        Field(expr) => {
+            collect_structs(&*expr.base, structs);
+        }
+    }
+}
+
+fn collect_struct_ty(ty: &Ty, structs: &mut BTreeSet<StructTy>) {
+    if let Ty::Struct(ref ty) = ty {
+        structs.insert(ty.clone());
+
+        for (name, ty) in ty.fields.iter() {
+            collect_structs(
+                &Expr::Var(VarExpr {
+                    ident: Ident::new(name),
+                    ty: ty.clone(),
+                    init: None,
+                }),
+                structs,
+            );
+        }
+    }
+}
+
+pub fn collect_funcs(expr: &Expr, funcs: &mut BTreeSet<DefFunc>) {
+    use Expr::*;
+
+    match expr {
+        Binary(expr) => {
+            collect_funcs(&*expr.left, funcs);
+            collect_funcs(&*expr.right, funcs);
+        }
+        Branch(expr) => {
+            collect_funcs(&*expr.cond, funcs);
+            collect_funcs(&*expr.true_expr, funcs);
+            collect_funcs(&*expr.false_expr, funcs);
+        }
+        Var(VarExpr {
+            init: Some(init), ..
+        }) => {
+            collect_funcs(init, funcs);
+        }
+        Var(VarExpr { init: None, .. }) => (),
+        Call(expr) => {
+            if let Func::Def(func) = &expr.func {
+                funcs.insert(func.clone());
+                collect_funcs(&*func.result, funcs);
+            }
+            for arg in &expr.args {
+                collect_funcs(arg, funcs);
+            }
+        }
+        Literal(_) => (),
+        Field(expr) => {
+            collect_funcs(&*expr.base, funcs);
+        }
+    }
+}
+
+pub fn collect_vars(expr: &Expr, vars: &mut BTreeSet<VarExpr>) {
+    use Expr::*;
+
+    match expr {
+        Binary(expr) => {
+            collect_vars(&*expr.left, vars);
+            collect_vars(&*expr.right, vars);
+        }
+        Branch(expr) => {
+            collect_vars(&*expr.cond, vars);
+            collect_vars(&*expr.true_expr, vars);
+            collect_vars(&*expr.false_expr, vars);
+        }
+        Var(
+            var @ VarExpr {
+                init: Some(init), ..
+            },
+        ) => {
+            vars.insert(var.clone());
+            collect_vars(init, vars);
+        }
+        Var(VarExpr { init: None, .. }) => (),
+        Call(expr) => {
+            for arg in &expr.args {
+                collect_vars(arg, vars);
+            }
+        }
+        Literal(_) => (),
+        Field(expr) => {
+            collect_vars(&*expr.base, vars);
+        }
+    }
+}

--- a/src/lang/show.rs
+++ b/src/lang/show.rs
@@ -40,7 +40,7 @@ pub fn show_lets<'a>(vars: impl IntoIterator<Item = &'a VarExpr>) -> String {
         .filter_map(|var| {
             var.init.as_ref().map(|init| {
                 format!(
-                    "let {}: {} = {};",
+                    "    let {}: {} = {};",
                     var.ident.to_string(),
                     show_ty(&var.ty),
                     show_expr(init),

--- a/src/lang/show.rs
+++ b/src/lang/show.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use super::{
     defs::{collect_vars, Defs},
-    BinaryOp, BuiltInTy, CallExpr, DefFunc, Expr, Func, ScalarTy, StructTy, Ty, VarExpr,
+    BinaryOp, BuiltInTy, DefFunc, Expr, ScalarTy, StructTy, Ty, VarExpr,
 };
 
 pub fn show_expr(expr: &Expr) -> String {

--- a/src/lang/show.rs
+++ b/src/lang/show.rs
@@ -1,276 +1,9 @@
 use std::collections::BTreeSet;
 
-use crate::lang::Ident;
-
 use super::{
-    BinaryOp, BuiltInTy, CallExpr, Expr, Func, ScalarTy, StructTy, Ty, UserDefinedFunc, VarExpr,
+    defs::{collect_vars, Defs},
+    BinaryOp, BuiltInTy, CallExpr, DefFunc, Expr, Func, ScalarTy, StructTy, Ty,
 };
-
-pub fn collect_struct_ty(ty: &Ty, structs: &mut BTreeSet<StructTy>) {
-    if let Ty::Struct(ref ty) = ty {
-        structs.insert(ty.clone());
-
-        for (name, ty) in ty.fields.iter() {
-            collect_structs(
-                &Expr::Var(VarExpr {
-                    ident: Ident::new(name),
-                    ty: ty.clone(),
-                    init: None,
-                }),
-                structs,
-            );
-        }
-    }
-}
-
-pub fn collect_structs(expr: &Expr, structs: &mut BTreeSet<StructTy>) {
-    use Expr::*;
-
-    collect_struct_ty(&expr.ty(), structs);
-
-    match expr {
-        Binary(expr) => {
-            collect_structs(&*expr.left, structs);
-            collect_structs(&*expr.right, structs);
-        }
-        Branch(expr) => {
-            collect_structs(&*expr.cond, structs);
-            collect_structs(&*expr.true_expr, structs);
-            collect_structs(&*expr.false_expr, structs);
-        }
-        Var(expr) => {
-            if let Some(ref init) = expr.init {
-                collect_structs(init, structs);
-            }
-        }
-        Call(expr) => {
-            if let Func::UserDefined(func) = &expr.func {
-                for param in func.params.iter() {
-                    collect_struct_ty(&param.ty, structs);
-                }
-                collect_structs(&*func.result, structs);
-            }
-
-            for arg in &expr.args {
-                collect_structs(arg, structs);
-            }
-        }
-        Literal(_) => (),
-        Field(expr) => {
-            collect_structs(&*expr.base, structs);
-        }
-    }
-}
-
-pub fn collect_funcs(expr: &Expr, funcs: &mut BTreeSet<UserDefinedFunc>) {
-    use Expr::*;
-
-    match expr {
-        Binary(expr) => {
-            collect_funcs(&*expr.left, funcs);
-            collect_funcs(&*expr.right, funcs);
-        }
-        Branch(expr) => {
-            collect_funcs(&*expr.cond, funcs);
-            collect_funcs(&*expr.true_expr, funcs);
-            collect_funcs(&*expr.false_expr, funcs);
-        }
-        Var(VarExpr {
-            init: Some(init), ..
-        }) => {
-            collect_funcs(init, funcs);
-        }
-        Var(VarExpr { init: None, .. }) => (),
-        Call(expr) => {
-            if let Func::UserDefined(func) = &expr.func {
-                funcs.insert(func.clone());
-                collect_funcs(&*func.result, funcs);
-            }
-            for arg in &expr.args {
-                collect_funcs(arg, funcs);
-            }
-        }
-        Literal(_) => (),
-        Field(expr) => {
-            collect_funcs(&*expr.base, funcs);
-        }
-    }
-}
-
-pub fn collect_vars(expr: &Expr, vars: &mut BTreeSet<VarExpr>) {
-    use Expr::*;
-
-    match expr {
-        Binary(expr) => {
-            collect_vars(&*expr.left, vars);
-            collect_vars(&*expr.right, vars);
-        }
-        Branch(expr) => {
-            collect_vars(&*expr.cond, vars);
-            collect_vars(&*expr.true_expr, vars);
-            collect_vars(&*expr.false_expr, vars);
-        }
-        Var(
-            var @ VarExpr {
-                init: Some(init), ..
-            },
-        ) => {
-            vars.insert(var.clone());
-            collect_vars(init, vars);
-        }
-        Var(VarExpr { init: None, .. }) => (),
-        Call(CallExpr { args, .. }) => {
-            for arg in args {
-                collect_vars(arg, vars);
-            }
-        }
-        Literal(_) => (),
-        Field(expr) => {
-            collect_vars(&*expr.base, vars);
-        }
-    }
-}
-
-fn show_scalar_ty(ty: ScalarTy) -> String {
-    use ScalarTy::*;
-
-    match ty {
-        Bool => "bool".to_string(),
-        I32 => "i32".to_string(),
-        U32 => "u32".to_string(),
-        F32 => "f32".to_string(),
-    }
-}
-
-fn scalar_type_prefix(ty: ScalarTy) -> String {
-    use ScalarTy::*;
-
-    match ty {
-        Bool => "b".to_string(),
-        I32 => "i".to_string(),
-        U32 => "u".to_string(),
-        F32 => "".to_string(),
-    }
-}
-
-fn show_built_in_ty(ty: &BuiltInTy) -> String {
-    use BuiltInTy::*;
-
-    match ty {
-        Scalar(ty) => show_scalar_ty(*ty),
-        Vec2(ty) => format!("{}vec2", scalar_type_prefix(*ty)),
-        Vec3(ty) => format!("{}vec3", scalar_type_prefix(*ty)),
-        Vec4(ty) => format!("{}vec4", scalar_type_prefix(*ty)),
-        Sampler2 => "sampler2D".to_string(),
-    }
-}
-
-fn show_struct_ty(ty: &StructTy) -> String {
-    ty.ident.to_string()
-}
-
-fn show_ty(ty: &Ty) -> String {
-    use Ty::*;
-
-    match ty {
-        BuiltIn(ty) => show_built_in_ty(ty),
-        Struct(ty) => show_struct_ty(ty),
-    }
-}
-
-fn show_struct_def(ty: &StructTy) -> String {
-    let fields: Vec<_> = ty
-        .fields
-        .iter()
-        .map(|(name, ty)| format!("    {}: {}", name, show_ty(ty)))
-        .collect();
-
-    format!(
-        "struct {}\n{{\n{}\n}};",
-        ty.ident.to_string(),
-        fields.join("\n")
-    )
-}
-
-pub fn show_user_defined_func(func: &UserDefinedFunc) -> String {
-    let params: Vec<_> = func
-        .params
-        .iter()
-        .map(|param| format!("{}: {}", param.ident.to_string(), show_ty(&param.ty)))
-        .collect();
-
-    let mut vars = BTreeSet::new();
-    collect_vars(&func.result, &mut vars);
-    // TODO: Sort vars by dependencies.
-
-    let lets: Vec<_> = vars
-        .iter()
-        .map(|var| {
-            format!(
-                "    let {}: {} = {};",
-                var.ident.to_string(),
-                show_ty(&var.ty),
-                show_expr(var.init.as_ref().unwrap())
-            )
-        })
-        .collect();
-
-    format!(
-        "fn {}({}) -> {} {{\n{}\n    {}\n}}",
-        func.ident.name,
-        params.join(", "),
-        show_ty(&func.result.ty()),
-        lets.join("\n"),
-        show_expr(&func.result),
-    )
-}
-
-pub fn show_user_defined_funcs(func: &UserDefinedFunc) -> String {
-    let mut funcs = BTreeSet::new();
-    collect_funcs(&*func.result, &mut funcs);
-    funcs.insert(func.clone());
-    // TODO: Sort funcs by dependencies.
-
-    let mut structs = BTreeSet::new();
-    for func in funcs.iter() {
-        collect_structs(
-            &Expr::Call(CallExpr {
-                func: Func::UserDefined(func.clone()),
-                args: Vec::new(),
-            }),
-            &mut structs,
-        );
-    }
-    // TODO: Sort structs by dependencies.
-
-    let struct_defs = structs
-        .iter()
-        .map(show_struct_def)
-        .collect::<Vec<_>>()
-        .join("\n\n");
-
-    let func_defs = funcs
-        .iter()
-        .map(show_user_defined_func)
-        .collect::<Vec<_>>()
-        .join("\n\n");
-
-    format!("{}\n\n{}", struct_defs, func_defs)
-}
-
-pub fn show_binary_op(op: BinaryOp) -> String {
-    use BinaryOp::*;
-
-    match op {
-        Add => "+".into(),
-        Sub => "-".into(),
-        Mul => "*".into(),
-        Div => "/".into(),
-        Eq => "==".into(),
-        And => "&&".into(),
-        Or => "||".into(),
-    }
-}
 
 pub fn show_expr(expr: &Expr) -> String {
     use Expr::*;
@@ -298,5 +31,132 @@ pub fn show_expr(expr: &Expr) -> String {
             let base = show_expr(&*expr.base);
             format!("({}).{}", base, expr.member)
         }
+    }
+}
+
+pub fn show_func_def(def: &DefFunc) -> String {
+    let params: Vec<_> = def
+        .params
+        .iter()
+        .map(|param| format!("{}: {}", param.ident.to_string(), show_ty(&param.ty)))
+        .collect();
+
+    // TODO: Sort vars by dependencies.
+    let mut vars = BTreeSet::new();
+    collect_vars(&def.result, &mut vars);
+
+    let lets: Vec<_> = vars
+        .iter()
+        .map(|var| {
+            format!(
+                "    let {}: {} = {};",
+                var.ident.to_string(),
+                show_ty(&var.ty),
+                show_expr(var.init.as_ref().unwrap())
+            )
+        })
+        .collect();
+
+    format!(
+        "fn {}({}) -> {} {{\n{}\n    {}\n}}",
+        def.ident.name,
+        params.join(", "),
+        show_ty(&def.result.ty()),
+        lets.join("\n"),
+        show_expr(&def.result),
+    )
+}
+
+pub fn show_defs(defs: &Defs) -> String {
+    // FIXME: Sort funcs and structs by dependencies.
+    let struct_defs = defs
+        .structs
+        .iter()
+        .map(show_struct_def)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let func_defs = defs
+        .funcs
+        .iter()
+        .map(show_func_def)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    format!("{}\n\n{}", struct_defs, func_defs)
+}
+
+pub fn show_scalar_ty(ty: ScalarTy) -> String {
+    use ScalarTy::*;
+
+    match ty {
+        Bool => "bool".to_string(),
+        I32 => "i32".to_string(),
+        U32 => "u32".to_string(),
+        F32 => "f32".to_string(),
+    }
+}
+
+fn scalar_type_prefix(ty: ScalarTy) -> String {
+    use ScalarTy::*;
+
+    match ty {
+        Bool => "b".to_string(),
+        I32 => "i".to_string(),
+        U32 => "u".to_string(),
+        F32 => "".to_string(),
+    }
+}
+
+pub fn show_built_in_ty(ty: &BuiltInTy) -> String {
+    use BuiltInTy::*;
+
+    match ty {
+        Scalar(ty) => show_scalar_ty(*ty),
+        Vec2(ty) => format!("{}vec2", scalar_type_prefix(*ty)),
+        Vec3(ty) => format!("{}vec3", scalar_type_prefix(*ty)),
+        Vec4(ty) => format!("{}vec4", scalar_type_prefix(*ty)),
+        Sampler2 => "sampler2D".to_string(),
+    }
+}
+
+pub fn show_struct_ty(ty: &StructTy) -> String {
+    ty.ident.to_string()
+}
+
+pub fn show_ty(ty: &Ty) -> String {
+    use Ty::*;
+
+    match ty {
+        BuiltIn(ty) => show_built_in_ty(ty),
+        Struct(ty) => show_struct_ty(ty),
+    }
+}
+
+pub fn show_struct_def(ty: &StructTy) -> String {
+    let fields: Vec<_> = ty
+        .fields
+        .iter()
+        .map(|(name, ty)| format!("    {}: {}", name, show_ty(ty)))
+        .collect();
+
+    format!(
+        "struct {}\n{{\n{}\n}};",
+        ty.ident.to_string(),
+        fields.join("\n")
+    )
+}
+
+pub fn show_binary_op(op: BinaryOp) -> String {
+    use BinaryOp::*;
+
+    match op {
+        Add => "+".into(),
+        Sub => "-".into(),
+        Mul => "*".into(),
+        Div => "/".into(),
+        Eq => "==".into(),
+        And => "&&".into(),
+        Or => "||".into(),
     }
 }

--- a/src/lang/show.rs
+++ b/src/lang/show.rs
@@ -143,11 +143,11 @@ pub fn show_struct_def(ty: &StructTy) -> String {
     let fields: Vec<_> = ty
         .fields
         .iter()
-        .map(|(name, ty)| format!("    {}: {}", name, show_ty(ty)))
+        .map(|(name, ty)| format!("    {}: {},", name, show_ty(ty)))
         .collect();
 
     format!(
-        "struct {}\n{{\n{}\n}};",
+        "struct {}\n{{\n{}\n}}",
         ty.ident.to_string(),
         fields.join("\n")
     )

--- a/src/lang/show.rs
+++ b/src/lang/show.rs
@@ -33,7 +33,7 @@ pub fn collect_structs(expr: &Expr, structs: &mut BTreeSet<StructTy>) {
             collect_structs(&*expr.left, structs);
             collect_structs(&*expr.right, structs);
         }
-        Ternary(expr) => {
+        Branch(expr) => {
             collect_structs(&*expr.cond, structs);
             collect_structs(&*expr.true_expr, structs);
             collect_structs(&*expr.false_expr, structs);
@@ -59,7 +59,6 @@ pub fn collect_structs(expr: &Expr, structs: &mut BTreeSet<StructTy>) {
         Field(expr) => {
             collect_structs(&*expr.base, structs);
         }
-        BuiltInVar(_) => (),
     }
 }
 
@@ -71,7 +70,7 @@ pub fn collect_funcs(expr: &Expr, funcs: &mut BTreeSet<UserDefinedFunc>) {
             collect_funcs(&*expr.left, funcs);
             collect_funcs(&*expr.right, funcs);
         }
-        Ternary(expr) => {
+        Branch(expr) => {
             collect_funcs(&*expr.cond, funcs);
             collect_funcs(&*expr.true_expr, funcs);
             collect_funcs(&*expr.false_expr, funcs);
@@ -95,7 +94,6 @@ pub fn collect_funcs(expr: &Expr, funcs: &mut BTreeSet<UserDefinedFunc>) {
         Field(expr) => {
             collect_funcs(&*expr.base, funcs);
         }
-        BuiltInVar(_) => (),
     }
 }
 
@@ -107,7 +105,7 @@ pub fn collect_vars(expr: &Expr, vars: &mut BTreeSet<VarExpr>) {
             collect_vars(&*expr.left, vars);
             collect_vars(&*expr.right, vars);
         }
-        Ternary(expr) => {
+        Branch(expr) => {
             collect_vars(&*expr.cond, vars);
             collect_vars(&*expr.true_expr, vars);
             collect_vars(&*expr.false_expr, vars);
@@ -130,7 +128,6 @@ pub fn collect_vars(expr: &Expr, vars: &mut BTreeSet<VarExpr>) {
         Field(expr) => {
             collect_vars(&*expr.base, vars);
         }
-        BuiltInVar(_) => (),
     }
 }
 
@@ -285,7 +282,7 @@ pub fn show_expr(expr: &Expr) -> String {
             show_binary_op(expr.op),
             show_expr(&*expr.right)
         ),
-        Ternary(expr) => format!(
+        Branch(expr) => format!(
             "if {} {{ {} }} else {{ {} }}",
             show_expr(&*expr.cond),
             show_expr(&*expr.true_expr),
@@ -301,6 +298,5 @@ pub fn show_expr(expr: &Expr) -> String {
             let base = show_expr(&*expr.base);
             format!("({}).{}", base, expr.member)
         }
-        BuiltInVar(expr) => expr.name.to_string(),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ pub mod shader;
 
 #[doc(hidden)]
 pub use static_assertions;
-#[doc(hidden)]
-pub use uuid;
 
 pub use expose::{
     var, vec2, vec3, vec4, BuiltInValue, Expose, FuncArg, GenValue, IntoRep, NumType, Rep,

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -15,22 +15,22 @@ use crate::{expose::Expose, lang::Expr, FuncArg, Rep};
 
 /// Description of a shader.
 pub struct Shader<R, V, F> {
-    vert_stage: ErasedVertStage,
-    frag_stage: ErasedFragStage,
+    v_stage: ErasedVStage,
+    f_stage: ErasedFStage,
     _phantom: PhantomData<(R, V, F)>,
 }
 
-struct ErasedVertStage {
+struct ErasedVStage {
     pub interps: Expr,
     pub position: Expr,
 }
 
-struct ErasedFragStage {
+struct ErasedFStage {
     pub frag: Expr,
     pub frag_depth: Option<Expr>,
 }
 
-impl ErasedVertStage {
+impl ErasedVStage {
     fn new<W>(out: VOut<W>) -> Self
     where
         W: Expose,
@@ -43,7 +43,7 @@ impl ErasedVertStage {
     }
 }
 
-impl ErasedFragStage {
+impl ErasedFStage {
     fn new<F>(out: FOut<F>) -> Self
     where
         F: Expose,
@@ -65,23 +65,23 @@ where
     V::Rep: Attributes,
     F::Rep: Fragment,
 {
-    pub fn new<W, VertStage, FragStage>(vert_stage: VertStage, frag_stage: FragStage) -> Self
+    pub fn new<W, VStage, FStage>(v_stage: VStage, f_stage: FStage) -> Self
     where
         W: Expose,
         W::Rep: Interpolants,
-        VertStage: FnOnce(Rep<R>, VArg<V>) -> VOut<W>,
-        FragStage: FnOnce(Rep<R>, FArg<W>) -> FOut<F>,
+        VStage: FnOnce(Rep<R>, VArg<V>) -> VOut<W>,
+        FStage: FnOnce(Rep<R>, FArg<W>) -> FOut<F>,
     {
         // FIXME: stage arg handling
-        let vert_out = vert_stage(R::Rep::stage_arg(), VArg::stage_arg());
-        let frag_out = frag_stage(R::Rep::stage_arg(), FArg::stage_arg());
+        let v_out = v_stage(R::Rep::stage_arg(), VArg::stage_arg());
+        let f_out = f_stage(R::Rep::stage_arg(), FArg::stage_arg());
 
-        let vert_stage = ErasedVertStage::new(vert_out);
-        let frag_stage = ErasedFragStage::new(frag_out);
+        let v_stage = ErasedVStage::new(v_out);
+        let f_stage = ErasedFStage::new(f_out);
 
         Self {
-            vert_stage,
-            frag_stage,
+            v_stage,
+            f_stage,
             _phantom: PhantomData,
         }
     }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -47,10 +47,10 @@ where
     {
         // FIXME: stage arg handling
         let v_out = v_stage(R::Rep::stage_arg(), ErasedVStage::stage_arg());
-        let f_out = f_stage(R::Rep::stage_arg(), FArg::stage_arg());
+        let f_out = f_stage(R::Rep::stage_arg(), ErasedFStage::stage_arg());
 
-        let v_stage = ErasedVStage::new::<V, _>(v_out);
-        let f_stage = ErasedFStage::new(f_out);
+        let v_stage = ErasedVStage::new::<V, W>(v_out);
+        let f_stage = ErasedFStage::new::<W, F>(f_out);
 
         let erased = ErasedShader { v_stage, f_stage };
 

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -1,3 +1,6 @@
+mod erased;
+#[doc(hidden)]
+pub mod fields;
 mod resource;
 pub mod show;
 mod stage;
@@ -5,6 +8,7 @@ mod vertex;
 
 use std::marker::PhantomData;
 
+pub use erased::{ErasedFStage, ErasedShader, ErasedVStage};
 pub use resource::{Resource, Resources, UniformBlock, UniformBlockField};
 pub use stage::{FArg, FOut, VArg, VOut};
 pub use vertex::{
@@ -17,25 +21,12 @@ use crate::{
     FuncArg, Rep,
 };
 
+use self::fields::Fields;
+
 /// Description of a shader.
 pub struct Shader<R, V, F> {
     erased: ErasedShader,
     _phantom: PhantomData<(R, V, F)>,
-}
-
-pub struct ErasedShader {
-    v_stage: ErasedVStage,
-    f_stage: ErasedFStage,
-}
-
-pub struct ErasedVStage {
-    pub interps: Expr,
-    pub pos: Expr,
-}
-
-pub struct ErasedFStage {
-    pub frag: Expr,
-    pub frag_depth: Option<Expr>,
 }
 
 impl<R, V, F> Shader<R, V, F>
@@ -55,10 +46,10 @@ where
         FStage: FnOnce(Rep<R>, FArg<W>) -> FOut<F>,
     {
         // FIXME: stage arg handling
-        let v_out = v_stage(R::Rep::stage_arg(), VArg::stage_arg());
+        let v_out = v_stage(R::Rep::stage_arg(), ErasedVStage::stage_arg());
         let f_out = f_stage(R::Rep::stage_arg(), FArg::stage_arg());
 
-        let v_stage = ErasedVStage::new(v_out);
+        let v_stage = ErasedVStage::new::<V, _>(v_out);
         let f_stage = ErasedFStage::new(f_out);
 
         let erased = ErasedShader { v_stage, f_stage };
@@ -71,61 +62,5 @@ where
 
     pub fn erased(&self) -> &ErasedShader {
         &self.erased
-    }
-}
-
-impl ErasedShader {
-    pub fn defs(&self) -> Defs {
-        let mut defs = Defs::new();
-
-        let exprs = self
-            .v_stage
-            .output_exprs()
-            .into_iter()
-            .chain(self.f_stage.output_exprs());
-        for expr in exprs {
-            defs.extend(&Defs::from_expr(expr));
-        }
-
-        defs
-    }
-}
-
-impl ErasedVStage {
-    fn new<W>(out: VOut<W>) -> Self
-    where
-        W: Expose,
-        W::Rep: Interpolants,
-    {
-        Self {
-            interps: out.interps.expr(),
-            pos: out.pos.expr(),
-        }
-    }
-
-    pub fn output_exprs(&self) -> impl IntoIterator<Item = &Expr> + '_ {
-        vec![&self.interps, &self.pos]
-    }
-}
-
-impl ErasedFStage {
-    fn new<F>(out: FOut<F>) -> Self
-    where
-        F: Expose,
-        F::Rep: Fragment,
-    {
-        Self {
-            frag: out.frag.expr(),
-            frag_depth: out.frag_depth.map(|v| v.expr()),
-        }
-    }
-
-    pub fn output_exprs(&self) -> impl IntoIterator<Item = &Expr> + '_ {
-        let mut exprs = vec![&self.frag];
-        if let Some(pos) = self.frag_depth.as_ref() {
-            exprs.push(pos);
-        }
-
-        exprs
     }
 }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -14,10 +14,10 @@ pub use vertex::{
 use crate::{expose::Expose, lang::Expr, FuncArg, Rep};
 
 /// Description of a shader.
-pub struct Shader<P, V, R> {
+pub struct Shader<R, V, F> {
     vert_stage: ErasedVertStage,
     frag_stage: ErasedFragStage,
-    _phantom: PhantomData<(P, V, R)>,
+    _phantom: PhantomData<(R, V, F)>,
 }
 
 struct ErasedVertStage {

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -21,7 +21,7 @@ use crate::{
     FuncArg, Rep,
 };
 
-use self::fields::Fields;
+use self::fields::{Fields, InputFields};
 
 /// Description of a shader.
 pub struct Shader<R, V, F> {
@@ -46,13 +46,24 @@ where
         FStage: FnOnce(Rep<R>, FArg<W>) -> FOut<F>,
     {
         // FIXME: stage arg handling
-        let v_out = v_stage(R::Rep::stage_arg(), ErasedVStage::stage_arg());
-        let f_out = f_stage(R::Rep::stage_arg(), ErasedFStage::stage_arg());
+        let v_out = v_stage(
+            <R::Rep as InputFields>::stage_input("res"),
+            ErasedVStage::stage_arg(),
+        );
+        let f_out = f_stage(
+            <R::Rep as InputFields>::stage_input("res"),
+            ErasedFStage::stage_arg(),
+        );
 
+        let res = <R::Rep as Fields>::fields("res");
         let v_stage = ErasedVStage::new::<V, W>(v_out);
         let f_stage = ErasedFStage::new::<W, F>(f_out);
 
-        let erased = ErasedShader { v_stage, f_stage };
+        let erased = ErasedShader {
+            res,
+            v_stage,
+            f_stage,
+        };
 
         Self {
             erased,

--- a/src/shader/erased.rs
+++ b/src/shader/erased.rs
@@ -1,0 +1,89 @@
+use crate::{
+    lang::{defs::Defs, Expr, Ty},
+    Expose, FuncArg,
+};
+
+use super::{fields::Fields, Attributes, FOut, Fragment, Interpolants, VArg, VOut};
+
+pub struct ErasedVStage {
+    pub attributes: Vec<(String, Ty)>,
+    pub interps: Expr,
+    pub pos: Expr,
+}
+
+pub struct ErasedFStage {
+    pub frag: Expr,
+    pub frag_depth: Option<Expr>,
+}
+
+pub struct ErasedShader {
+    pub v_stage: ErasedVStage,
+    pub f_stage: ErasedFStage,
+}
+
+impl ErasedShader {
+    pub fn defs(&self) -> Defs {
+        let mut defs = Defs::new();
+
+        let exprs = self
+            .v_stage
+            .output_exprs()
+            .into_iter()
+            .chain(self.f_stage.output_exprs());
+        for expr in exprs {
+            defs.extend(&Defs::from_expr(expr));
+        }
+
+        defs
+    }
+}
+
+impl ErasedVStage {
+    pub(crate) fn new<V, W>(out: VOut<W>) -> Self
+    where
+        V: Expose,
+        V::Rep: Attributes,
+        W: Expose,
+        W::Rep: Interpolants,
+    {
+        Self {
+            attributes: <V::Rep as Fields>::fields("attrs"),
+            interps: out.interps.expr(),
+            pos: out.pos.expr(),
+        }
+    }
+
+    pub fn stage_arg<V>() -> VArg<V>
+    where
+        V: Expose,
+        V::Rep: Attributes,
+    {
+        VArg::new(<V::Rep as Fields>::stage_input("attrs"))
+    }
+
+    pub fn output_exprs(&self) -> impl IntoIterator<Item = &Expr> + '_ {
+        vec![&self.interps, &self.pos]
+    }
+}
+
+impl ErasedFStage {
+    pub(crate) fn new<F>(out: FOut<F>) -> Self
+    where
+        F: Expose,
+        F::Rep: Fragment,
+    {
+        Self {
+            frag: out.frag.expr(),
+            frag_depth: out.frag_depth.map(|v| v.expr()),
+        }
+    }
+
+    pub fn output_exprs(&self) -> impl IntoIterator<Item = &Expr> + '_ {
+        let mut exprs = vec![&self.frag];
+        if let Some(pos) = self.frag_depth.as_ref() {
+            exprs.push(pos);
+        }
+
+        exprs
+    }
+}

--- a/src/shader/erased.rs
+++ b/src/shader/erased.rs
@@ -23,6 +23,7 @@ pub struct ErasedFStage {
 }
 
 pub struct ErasedShader {
+    pub res: Vec<(String, Ty)>,
     pub v_stage: ErasedVStage,
     pub f_stage: ErasedFStage,
 }

--- a/src/shader/erased.rs
+++ b/src/shader/erased.rs
@@ -3,7 +3,10 @@ use crate::{
     Expose, FuncArg,
 };
 
-use super::{fields::Fields, Attributes, FOut, Fragment, Interpolants, VArg, VOut};
+use super::{
+    fields::{Fields, InputFields},
+    Attributes, FOut, Fragment, Interpolants, VArg, VOut,
+};
 
 pub struct ErasedVStage {
     pub attributes: Vec<(String, Ty)>,
@@ -58,7 +61,7 @@ impl ErasedVStage {
         V: Expose,
         V::Rep: Attributes,
     {
-        VArg::new(<V::Rep as Fields>::stage_input("attrs"))
+        VArg::new(<V::Rep as InputFields>::stage_input("attrs"))
     }
 
     pub fn output_exprs(&self) -> impl IntoIterator<Item = &Expr> + '_ {

--- a/src/shader/erased.rs
+++ b/src/shader/erased.rs
@@ -27,23 +27,6 @@ pub struct ErasedShader {
     pub f_stage: ErasedFStage,
 }
 
-impl ErasedShader {
-    pub fn defs(&self) -> Defs {
-        let mut defs = Defs::new();
-
-        let exprs = self
-            .v_stage
-            .output_exprs()
-            .into_iter()
-            .chain(self.f_stage.output_exprs());
-        for expr in exprs {
-            defs.extend(&Defs::from_expr(expr));
-        }
-
-        defs
-    }
-}
-
 impl ErasedVStage {
     pub(crate) fn new<V, W>(out: VOut<W>) -> Self
     where
@@ -72,6 +55,16 @@ impl ErasedVStage {
             .iter()
             .map(|(_, expr)| expr)
             .chain(iter::once(&self.pos))
+    }
+
+    pub fn defs(&self) -> Defs {
+        let mut defs = Defs::new();
+
+        for expr in self.output_exprs() {
+            defs.extend(&Defs::from_expr(expr));
+        }
+
+        defs
     }
 }
 
@@ -103,5 +96,15 @@ impl ErasedFStage {
             .iter()
             .map(|(_, expr)| expr)
             .chain(self.frag_depth.as_ref())
+    }
+
+    pub fn defs(&self) -> Defs {
+        let mut defs = Defs::new();
+
+        for expr in self.output_exprs() {
+            defs.extend(&Defs::from_expr(expr));
+        }
+
+        defs
     }
 }

--- a/src/shader/fields.rs
+++ b/src/shader/fields.rs
@@ -15,5 +15,5 @@ pub trait InputFields: Fields {
 }
 
 pub trait OutputFields: Fields {
-    fn stage_output(self) -> Vec<(String, Expr)>;
+    fn stage_output(self, prefix: &str) -> Vec<(String, Expr)>;
 }

--- a/src/shader/fields.rs
+++ b/src/shader/fields.rs
@@ -1,4 +1,4 @@
-use crate::lang::Ty;
+use crate::lang::{Expr, Ty};
 
 #[doc(hidden)]
 pub fn add_prefix(lhs: &str, rhs: &str) -> String {
@@ -12,4 +12,8 @@ pub trait Fields {
 pub trait InputFields: Fields {
     #[doc(hidden)]
     fn stage_input(prefix: &str) -> Self;
+}
+
+pub trait OutputFields: Fields {
+    fn stage_output(self) -> Vec<(String, Expr)>;
 }

--- a/src/shader/fields.rs
+++ b/src/shader/fields.rs
@@ -1,0 +1,13 @@
+use crate::lang::Ty;
+
+#[doc(hidden)]
+pub fn add_prefix(lhs: &str, rhs: &str) -> String {
+    format!("{}_{}", lhs, rhs)
+}
+
+pub trait Fields {
+    fn fields(prefix: &str) -> Vec<(String, Ty)>;
+
+    #[doc(hidden)]
+    fn stage_input(prefix: &str) -> Self;
+}

--- a/src/shader/fields.rs
+++ b/src/shader/fields.rs
@@ -7,7 +7,9 @@ pub fn add_prefix(lhs: &str, rhs: &str) -> String {
 
 pub trait Fields {
     fn fields(prefix: &str) -> Vec<(String, Ty)>;
+}
 
+pub trait InputFields: Fields {
     #[doc(hidden)]
     fn stage_input(prefix: &str) -> Self;
 }

--- a/src/shader/resource.rs
+++ b/src/shader/resource.rs
@@ -1,33 +1,39 @@
 use sealed::sealed;
 
-use crate::{Representative, Value};
+use crate::{
+    lang::{Ident, Ty},
+    FuncArg, Representative, Value,
+};
+
+use super::fields::{Fields, InputFields};
 
 /// A representative of a resource that can be bound to shaders.
-pub trait Resource: Representative {
-    #[doc(hidden)]
-    fn stage_arg() -> Self;
-}
+pub trait Resource: FuncArg + InputFields {}
 
 /// A representative of a uniform block.
 pub trait UniformBlock: Resource + Value {}
 
 /// A representative of a collection of resources that can be bound to shaders.
-pub trait Resources {
-    #[doc(hidden)]
-    fn stage_arg() -> Self;
-
+pub trait Resources: InputFields {
     #[doc(hidden)]
     fn must_impl() {}
 }
 
-impl<D> Resources for D
-where
-    D: Resource,
-{
-    fn stage_arg() -> Self {
-        <Self as Resource>::stage_arg()
+/*
+impl<D: Resource> Fields for D {
+    fn fields(prefix: &str) -> Vec<(String, Ty)> {
+        vec![(prefix.into(), <D as FuncArg>::ty())]
     }
 }
+
+impl<D: Resource> InputFields for D {
+    fn stage_input(prefix: &str) -> Self {
+        <D as FuncArg>::from_ident(Ident::new(prefix))
+    }
+}
+*/
+
+impl<D: Resource> Resources for D {}
 
 /// A representative that can be stored in a [`UniformBlock`].
 #[sealed]

--- a/src/shader/show.rs
+++ b/src/shader/show.rs
@@ -36,7 +36,7 @@ fn show_main<'a>(
     result
 }
 
-fn show_v_stage(stage: &ErasedVStage) -> String {
+fn show_v_stage(res: &str, stage: &ErasedVStage) -> String {
     let mut vars = BTreeSet::new();
     for expr in stage.output_exprs() {
         collect_vars(expr, &mut vars);
@@ -51,6 +51,9 @@ fn show_v_stage(stage: &ErasedVStage) -> String {
     let mut result = String::new();
 
     result += &show_defs(&stage.defs());
+
+    result += "\n\n";
+    result += res;
 
     result += "\n\n";
     result += &show_interface("attribute", stage.attrs.iter().cloned());
@@ -70,7 +73,7 @@ fn show_v_stage(stage: &ErasedVStage) -> String {
     result
 }
 
-fn show_f_stage(stage: &ErasedFStage) -> String {
+fn show_f_stage(res: &str, stage: &ErasedFStage) -> String {
     let mut vars = BTreeSet::new();
     for expr in stage.output_exprs() {
         collect_vars(expr, &mut vars);
@@ -92,6 +95,9 @@ fn show_f_stage(stage: &ErasedFStage) -> String {
     result += &show_defs(&stage.defs());
 
     result += "\n\n";
+    result += res;
+
+    result += "\n\n";
     result += &show_interface("in", stage.interps.iter().cloned());
 
     result += "\n\n";
@@ -110,9 +116,11 @@ fn show_f_stage(stage: &ErasedFStage) -> String {
 }
 
 pub fn show_shader(shader: &ErasedShader) -> String {
+    let res = show_interface("uniform", shader.res.iter().cloned());
+
     format!(
         "{}\n============================================================================\n\n{}",
-        show_v_stage(&shader.v_stage),
-        show_f_stage(&shader.f_stage)
+        show_v_stage(&res, &shader.v_stage),
+        show_f_stage(&res, &shader.f_stage)
     )
 }

--- a/src/shader/show.rs
+++ b/src/shader/show.rs
@@ -56,7 +56,7 @@ fn show_v_stage(res: &str, stage: &ErasedVStage) -> String {
     result += res;
 
     result += "\n\n";
-    result += &show_interface("attribute", stage.attrs.iter().cloned());
+    result += &show_interface("in", stage.attrs.iter().cloned());
 
     result += "\n\n";
     result += &show_interface(

--- a/src/shader/show.rs
+++ b/src/shader/show.rs
@@ -3,9 +3,18 @@ use std::collections::BTreeSet;
 use crate::lang::{
     defs::collect_vars,
     show::{show_defs, show_expr, show_lets, show_ty},
+    Ty,
 };
 
 use super::{ErasedFStage, ErasedShader, ErasedVStage};
+
+fn interface(kind: &str, fields: impl IntoIterator<Item = (String, Ty)>) -> String {
+    fields
+        .into_iter()
+        .map(|(name, ty)| format!("{} {}: {};", kind, name, show_ty(&ty)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 fn show_v_stage(v_stage: &ErasedVStage) -> String {
     let mut vars = BTreeSet::new();
@@ -14,17 +23,22 @@ fn show_v_stage(v_stage: &ErasedVStage) -> String {
     }
 
     let mut result = String::new();
-    result += &v_stage
-        .attributes
-        .iter()
-        .map(|(name, ty)| format!("attribute {}: {};", name, show_ty(ty)))
-        .collect::<Vec<_>>()
-        .join("\n");
-    result += "\n";
+    result += &interface("attribute", v_stage.attrs.iter().cloned());
+    result += "\n\n";
+    result += &interface(
+        "out",
+        v_stage
+            .interps
+            .iter()
+            .map(|(name, expr)| (name.clone(), expr.ty())),
+    );
+    result += "\n\n";
     result += &show_lets(&vars);
     result += "\n";
-    result += &format!("interps := {};\n", show_expr(&v_stage.interps));
-    result += &format!("pos := {};\n", show_expr(&v_stage.pos));
+    for (name, expr) in &v_stage.interps {
+        result += &format!("{} := {};\n", name, show_expr(expr));
+    }
+    result += &format!("gl_Position := {};\n", show_expr(&v_stage.pos));
 
     result
 }
@@ -36,9 +50,21 @@ fn show_f_stage(f_stage: &ErasedFStage) -> String {
     }
 
     let mut result = String::new();
-    result += &show_lets(&vars);
+    result += &interface("in", f_stage.interps.iter().cloned());
     result += "\n\n";
-    result += &format!("frag := {};\n", show_expr(&f_stage.frag));
+    result += &interface(
+        "out",
+        f_stage
+            .frag
+            .iter()
+            .map(|(name, expr)| (name.clone(), expr.ty())),
+    );
+    result += "\n\n";
+    result += &show_lets(&vars);
+    result += "\n";
+    for (name, expr) in &f_stage.frag {
+        result += &format!("{} := {};\n", name, show_expr(expr));
+    }
 
     if let Some(frag_depth) = f_stage.frag_depth.as_ref() {
         result += &format!("frag_depth := {};\n", show_expr(frag_depth));

--- a/src/shader/show.rs
+++ b/src/shader/show.rs
@@ -1,0 +1,57 @@
+use std::collections::BTreeSet;
+
+use crate::lang::{
+    defs::collect_vars,
+    show::{show_defs, show_expr, show_lets, show_ty},
+};
+
+use super::{ErasedFStage, ErasedShader, ErasedVStage};
+
+fn show_v_stage(v_stage: &ErasedVStage) -> String {
+    let mut vars = BTreeSet::new();
+    for expr in v_stage.output_exprs() {
+        collect_vars(expr, &mut vars);
+    }
+
+    let mut result = String::new();
+    result += &v_stage
+        .attributes
+        .iter()
+        .map(|(name, ty)| format!("attribute {}: {};", name, show_ty(ty)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    result += "\n";
+    result += &show_lets(&vars);
+    result += "\n";
+    result += &format!("interps := {};\n", show_expr(&v_stage.interps));
+    result += &format!("pos := {};\n", show_expr(&v_stage.pos));
+
+    result
+}
+
+fn show_f_stage(f_stage: &ErasedFStage) -> String {
+    let mut vars = BTreeSet::new();
+    for expr in f_stage.output_exprs() {
+        collect_vars(expr, &mut vars);
+    }
+
+    let mut result = String::new();
+    result += &show_lets(&vars);
+    result += "\n\n";
+    result += &format!("frag := {};\n", show_expr(&f_stage.frag));
+
+    if let Some(frag_depth) = f_stage.frag_depth.as_ref() {
+        result += &format!("frag_depth := {};\n", show_expr(frag_depth));
+    }
+
+    result
+}
+
+pub fn show_shader(shader: &ErasedShader) -> String {
+    format!(
+        "{}\n{}\n============================================================================\n\n{}",
+        show_defs(&shader.defs()),
+        show_v_stage(&shader.v_stage),
+        show_f_stage(&shader.f_stage)
+    )
+}

--- a/src/shader/stage.rs
+++ b/src/shader/stage.rs
@@ -19,17 +19,12 @@ where
     V: Expose,
     V::Rep: Attributes,
 {
-    fn new(attrs: Rep<V>) -> Self {
+    pub(super) fn new(attrs: Rep<V>) -> Self {
         Self {
             attrs,
             vertex_id: builtin_var("gl_VertexID"),
             instance_id: builtin_var("gl_InstanceID"),
         }
-    }
-
-    pub(crate) fn stage_arg() -> Self {
-        // FIXME: stage arg handling
-        Self::new(Rep::<V>::from_ident(Ident::new("input")))
     }
 }
 

--- a/src/shader/stage.rs
+++ b/src/shader/stage.rs
@@ -14,6 +14,25 @@ where
     pub instance_id: Rep<i32>,
 }
 
+impl<V> VArg<V>
+where
+    V: Expose,
+    V::Rep: Attributes,
+{
+    fn new(attrs: Rep<V>) -> Self {
+        Self {
+            attrs,
+            vertex_id: builtin_var("gl_VertexID"),
+            instance_id: builtin_var("gl_InstanceID"),
+        }
+    }
+
+    pub(crate) fn stage_arg() -> Self {
+        // FIXME: stage arg handling
+        Self::new(Rep::<V>::from_ident(Ident::new("input")))
+    }
+}
+
 /// Output produced by vertex stages.
 pub struct VOut<W>
 where
@@ -34,39 +53,6 @@ where
     pub frag_coord: Vec4<f32>,
 }
 
-/// Output produced by fragment stages.
-pub struct FOut<F>
-where
-    F: Expose,
-    F::Rep: Fragment,
-{
-    pub frag: Rep<F>,
-    pub frag_depth: Option<Rep<f32>>,
-}
-
-fn builtin_var<V: FuncArg>(name: &'static str) -> V {
-    V::from_ident(Ident::new(name))
-}
-
-impl<V> VArg<V>
-where
-    V: Expose,
-    V::Rep: Attributes,
-{
-    fn new(attrs: Rep<V>) -> Self {
-        Self {
-            attrs,
-            vertex_id: builtin_var("gl_VertexID"),
-            instance_id: builtin_var("gl_InstanceID"),
-        }
-    }
-
-    pub(crate) fn stage_arg() -> Self {
-        // FIXME: stage arg handling
-        Self::new(Rep::<V>::from_ident(Ident::new("input")))
-    }
-}
-
 impl<W> FArg<W>
 where
     W: Expose,
@@ -85,6 +71,16 @@ where
     }
 }
 
+/// Output produced by fragment stages.
+pub struct FOut<F>
+where
+    F: Expose,
+    F::Rep: Fragment,
+{
+    pub frag: Rep<F>,
+    pub frag_depth: Option<Rep<f32>>,
+}
+
 impl<F> FOut<F>
 where
     F: Expose,
@@ -96,4 +92,8 @@ where
             frag_depth: None,
         }
     }
+}
+
+fn builtin_var<V: FuncArg>(name: &'static str) -> V {
+    V::from_ident(Ident::new(name))
 }

--- a/src/shader/stage.rs
+++ b/src/shader/stage.rs
@@ -19,7 +19,7 @@ where
     V: Expose,
     V::Rep: Attributes,
 {
-    pub(super) fn new(attrs: Rep<V>) -> Self {
+    pub(crate) fn new(attrs: Rep<V>) -> Self {
         Self {
             attrs,
             vertex_id: builtin_var("gl_VertexID"),
@@ -53,16 +53,11 @@ where
     W: Expose,
     W::Rep: Interpolants,
 {
-    fn new(inputs: Rep<W>) -> Self {
+    pub(crate) fn new(inputs: Rep<W>) -> Self {
         Self {
             interps: inputs,
             frag_coord: builtin_var("gl_FragCoord"),
         }
-    }
-
-    pub(crate) fn stage_arg() -> Self {
-        // FIXME: stage arg handling
-        Self::new(Rep::<W>::from_ident(Ident::new("input")))
     }
 }
 

--- a/src/shader/stage.rs
+++ b/src/shader/stage.rs
@@ -40,7 +40,7 @@ where
     W::Rep: Interpolants,
 {
     pub interps: Rep<W>,
-    pub position: Vec3<f32>,
+    pub pos: Vec3<f32>,
 }
 
 /// Argument passed to fragment stages.

--- a/src/shader/vertex.rs
+++ b/src/shader/vertex.rs
@@ -2,7 +2,7 @@ use sealed::sealed;
 
 use crate::{expose::NumType, lang::Ty, Scalar, Value, Vec2, Vec3, Vec4};
 
-use super::fields::{add_prefix, Fields};
+use super::fields::{add_prefix, Fields, InputFields};
 
 /// A representative that can be stored in a [`Vertex`].
 #[sealed]
@@ -26,10 +26,10 @@ impl<T: NumType> VertexField for Vec4<T> {}
 // TODO: VertexFieldValue for f32 matrix types
 
 /// A representative of a vertex.
-pub trait Vertex: Value + Fields {}
+pub trait Vertex: Value + InputFields {}
 
 /// A representative of vertex stage input.
-pub trait Attributes: Value + Fields {}
+pub trait Attributes: Value + InputFields {}
 
 impl<V: Vertex> Attributes for V {}
 
@@ -40,7 +40,9 @@ impl<V0: Vertex, V1: Vertex> Fields for (V0, V1) {
             .chain(V1::fields(&add_prefix(prefix, "x1")))
             .collect()
     }
+}
 
+impl<V0: Vertex, V1: Vertex> InputFields for (V0, V1) {
     fn stage_input(prefix: &str) -> Self {
         (
             V0::stage_input(&add_prefix(prefix, "x0")),

--- a/src/shader/vertex.rs
+++ b/src/shader/vertex.rs
@@ -1,14 +1,66 @@
 use sealed::sealed;
 
-use crate::{expose::NumType, lang::Ty, Scalar, Value, Vec2, Vec3, Vec4};
+use crate::{
+    expose::NumType,
+    lang::{Ident, Ty},
+    FuncArg, Scalar, Value, Vec2, Vec3, Vec4,
+};
 
 use super::fields::{add_prefix, Fields, InputFields, OutputFields};
 
 /// A representative that can be stored in a [`Vertex`].
 #[sealed]
-pub trait VertexField: Value {
+pub trait VertexField: Value + InputFields {
     #[doc(hidden)]
     fn must_impl() {}
+}
+
+impl<T: NumType> Fields for Scalar<T> {
+    fn fields(prefix: &str) -> Vec<(String, Ty)> {
+        vec![(prefix.into(), <Self as FuncArg>::ty())]
+    }
+}
+
+impl<T: NumType> Fields for Vec2<T> {
+    fn fields(prefix: &str) -> Vec<(String, Ty)> {
+        vec![(prefix.into(), <Self as FuncArg>::ty())]
+    }
+}
+
+impl<T: NumType> Fields for Vec3<T> {
+    fn fields(prefix: &str) -> Vec<(String, Ty)> {
+        vec![(prefix.into(), <Self as FuncArg>::ty())]
+    }
+}
+
+impl<T: NumType> Fields for Vec4<T> {
+    fn fields(prefix: &str) -> Vec<(String, Ty)> {
+        vec![(prefix.into(), <Self as FuncArg>::ty())]
+    }
+}
+
+impl<T: NumType> InputFields for Scalar<T> {
+    fn stage_input(prefix: &str) -> Self {
+        Self::from_ident(Ident::new(prefix))
+    }
+}
+
+impl<T: NumType> InputFields for Vec2<T> {
+    fn stage_input(prefix: &str) -> Self {
+        Self::from_ident(Ident::new(prefix))
+    }
+}
+
+impl<T: NumType> InputFields for Vec3<T> {
+    fn stage_input(prefix: &str) -> Self {
+        Self::from_ident(Ident::new(prefix))
+    }
+}
+
+impl<T: NumType> InputFields for Vec4<T> {
+    fn stage_input(prefix: &str) -> Self {
+        Self::from_ident(Ident::new(prefix))
+    }
 }
 
 #[sealed]
@@ -23,7 +75,7 @@ impl<T: NumType> VertexField for Vec3<T> {}
 #[sealed]
 impl<T: NumType> VertexField for Vec4<T> {}
 
-// TODO: VertexFieldValue for f32 matrix types
+// TODO: VertexField for f32 matrix types
 
 /// A representative of a vertex.
 pub trait Vertex: Value + InputFields {}
@@ -58,7 +110,7 @@ pub trait Interpolants: Value + InputFields + OutputFields {}
 
 /// A representative that can be stored in [`Interpolants`].
 #[sealed]
-pub trait InterpolantsField {
+pub trait InterpolantsField: Value + InputFields {
     #[doc(hidden)]
     fn must_impl() {}
 }

--- a/src/shader/vertex.rs
+++ b/src/shader/vertex.rs
@@ -2,7 +2,7 @@ use sealed::sealed;
 
 use crate::{expose::NumType, lang::Ty, Scalar, Value, Vec2, Vec3, Vec4};
 
-use super::fields::{add_prefix, Fields, InputFields};
+use super::fields::{add_prefix, Fields, InputFields, OutputFields};
 
 /// A representative that can be stored in a [`Vertex`].
 #[sealed]
@@ -54,7 +54,7 @@ impl<V0: Vertex, V1: Vertex> InputFields for (V0, V1) {
 impl<V1: Vertex, V2: Vertex> Attributes for (V1, V2) {}
 
 /// A representative of vertex stage output and fragment stage input.
-pub trait Interpolants: Value {}
+pub trait Interpolants: Value + InputFields + OutputFields {}
 
 /// A representative that can be stored in [`Interpolants`].
 #[sealed]
@@ -82,7 +82,7 @@ impl<T: NumType> InterpolantsField for Vec4<T> {}
 impl<V: Interpolants> InterpolantsField for V {}
 
 /// A representative of fragment stage output.
-pub trait Fragment: Value {}
+pub trait Fragment: Value + OutputFields {}
 
 /// A representative that can be stored in a [`Fragment`].
 #[sealed]

--- a/src/shader/vertex.rs
+++ b/src/shader/vertex.rs
@@ -1,6 +1,8 @@
 use sealed::sealed;
 
-use crate::{expose::NumType, Scalar, Value, Vec2, Vec3, Vec4};
+use crate::{expose::NumType, lang::Ty, Scalar, Value, Vec2, Vec3, Vec4};
+
+use super::fields::{add_prefix, Fields};
 
 /// A representative that can be stored in a [`Vertex`].
 #[sealed]
@@ -24,12 +26,28 @@ impl<T: NumType> VertexField for Vec4<T> {}
 // TODO: VertexFieldValue for f32 matrix types
 
 /// A representative of a vertex.
-pub trait Vertex: Value {}
+pub trait Vertex: Value + Fields {}
 
 /// A representative of vertex stage input.
-pub trait Attributes: Value {}
+pub trait Attributes: Value + Fields {}
 
 impl<V: Vertex> Attributes for V {}
+
+impl<V0: Vertex, V1: Vertex> Fields for (V0, V1) {
+    fn fields(prefix: &str) -> Vec<(String, Ty)> {
+        V0::fields(&add_prefix(prefix, "x0"))
+            .into_iter()
+            .chain(V1::fields(&add_prefix(prefix, "x1")))
+            .collect()
+    }
+
+    fn stage_input(prefix: &str) -> Self {
+        (
+            V0::stage_input(&add_prefix(prefix, "x0")),
+            V1::stage_input(&add_prefix(prefix, "x1")),
+        )
+    }
+}
 
 impl<V1: Vertex, V2: Vertex> Attributes for (V1, V2) {}
 


### PR DESCRIPTION
Closes #8 and #9.

Also:
- Cleans up the `show` code
- Adds a util for showing a single Posh function
- Renames `ternary` to `branch`
- Fixes #16 by removing UUIDs