### PR TITLE
Clean up ownership

### DIFF
--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -142,10 +142,7 @@ impl Demo {
         self.post_program.draw(
             PostUniforms {
                 globals: self.globals.binding(),
-                scene: self
-                    .framebuffer
-                    .attachments()
-                    .sampler(Sampler2dParams::default()),
+                scene: self.framebuffer.view().sampler(Sampler2dParams::default()),
             },
             VertexStream::Indexed {
                 vertices: self.quad_vertices.binding(),

--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -128,7 +128,7 @@ impl Demo {
         let time = Instant::now().duration_since(self.start_time).as_secs_f32();
         self.globals.set(Globals { time, flip });
 
-        self.context.clear_color([0.1, 0.2, 0.3, 1.0]);
+        self.context.clear_color(glam::vec4(0.1, 0.2, 0.3, 1.0));
         self.scene_program.draw(
             self.globals.binding(),
             VertexStream::Unindexed {

--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -145,7 +145,7 @@ impl Demo {
                 scene: self
                     .framebuffer
                     .attachments()
-                    .binding(Sampler2dParams::default()),
+                    .sampler(Sampler2dParams::default()),
             },
             VertexStream::Indexed {
                 vertices: self.quad_vertices.binding(),

--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -67,7 +67,7 @@ impl Demo {
         let time = Instant::now().duration_since(self.start_time).as_secs_f32();
         self.globals.set(Globals { time });
 
-        self.context.clear_color([0.1, 0.2, 0.3, 1.0]);
+        self.context.clear_color(glam::vec4(0.1, 0.2, 0.3, 1.0));
         self.program.draw(
             self.globals.binding(),
             VertexStream::Unindexed {

--- a/examples/textured_cube.rs
+++ b/examples/textured_cube.rs
@@ -121,7 +121,7 @@ impl Demo {
         let time = Instant::now().duration_since(self.start_time).as_secs_f32();
         self.time.set(time);
 
-        self.context.clear_color([0.1, 0.2, 0.3, 1.0]);
+        self.context.clear_color(glam::vec4(0.1, 0.2, 0.3, 1.0));
         self.program.draw(
             (
                 Uniform {

--- a/examples/textured_cube.rs
+++ b/examples/textured_cube.rs
@@ -128,7 +128,7 @@ impl Demo {
                     camera: self.camera.binding(),
                     time: self.time.binding(),
                 },
-                self.texture.binding(Sampler2dParams::default()),
+                self.texture.sampler(Sampler2dParams::default()),
             ),
             VertexStream::Indexed {
                 vertices: self.vertices.binding(),

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -21,7 +21,7 @@ pub use raw::{
     FramebufferError, PrimitiveType, ProgramError, ProgramValidationError, Sampler2dParams,
     TextureError, VertexArrayError,
 };
-pub use texture::{Texture2d, Texture2dBinding};
+pub use texture::{Sampler2d, Texture2d};
 pub use uniform_buffer::{UniformBuffer, UniformBufferBinding};
 pub use vertex_buffer::{VertexBuffer, VertexBufferBinding};
 pub use vertex_stream::VertexStream;

--- a/src/gl/context.rs
+++ b/src/gl/context.rs
@@ -30,10 +30,6 @@ impl Context {
         Ok(Self { raw })
     }
 
-    pub fn gl(&self) -> &Rc<glow::Context> {
-        self.raw.gl()
-    }
-
     pub fn caps(&self) -> &Caps {
         self.raw.caps()
     }
@@ -184,12 +180,7 @@ impl Context {
 
     // TODO: Clearing should move to some framebuffer thing.
 
-    pub fn clear_color(&self, color: [f32; 4]) {
-        let gl = self.raw.gl();
-
-        unsafe {
-            gl.clear_color(color[0], color[1], color[2], color[3]);
-            gl.clear(glow::COLOR_BUFFER_BIT);
-        }
+    pub fn clear_color(&self, color: glam::Vec4) {
+        self.raw.clear_color(color);
     }
 }

--- a/src/gl/context.rs
+++ b/src/gl/context.rs
@@ -1,7 +1,4 @@
-use std::rc::Rc;
-
 use crevice::std140::AsStd140;
-use glow::HasContext;
 
 use crate::{
     sl::{

--- a/src/gl/element_buffer.rs
+++ b/src/gl/element_buffer.rs
@@ -77,7 +77,7 @@ impl<E: Element> ElementBuffer<E> {
 }
 
 impl ElementBufferBinding {
-    pub(crate) fn raw(&self) -> &raw::Buffer {
+    pub(crate) fn raw(&self) -> &Rc<raw::Buffer> {
         &self.raw
     }
 

--- a/src/gl/element_buffer.rs
+++ b/src/gl/element_buffer.rs
@@ -24,7 +24,6 @@ impl Element for u32 {
 ///
 /// Instances of `ElementBuffer` can be created with
 /// [`Context::create_element_buffer`](crate::gl::Context::create_element_buffer).
-#[derive(Clone)]
 pub struct ElementBuffer<E = u32> {
     raw: Rc<raw::Buffer>,
     _phantom: PhantomData<E>,

--- a/src/gl/framebuffer.rs
+++ b/src/gl/framebuffer.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::{
     raw::{self, FramebufferError},
-    Sampler2dParams, Texture2d, Texture2dBinding,
+    Sampler2d, Sampler2dParams, Texture2d,
 };
 
 pub struct FramebufferAttachment2d<S> {
@@ -44,8 +44,8 @@ impl<S: Sample> FramebufferAttachment2d<S> {
         self.level
     }
 
-    pub fn binding(&self, params: Sampler2dParams) -> Texture2dBinding<S> {
-        self.texture.binding(params)
+    pub fn sampler(&self, params: Sampler2dParams) -> Sampler2d<S> {
+        self.texture.sampler(params)
     }
 }
 

--- a/src/gl/framebuffer.rs
+++ b/src/gl/framebuffer.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, rc::Rc};
 
 use crate::{
     interface::FragmentVisitor,
@@ -8,44 +8,44 @@ use crate::{
 
 use super::{
     raw::{self, FramebufferError},
-    Sampler2d, Sampler2dParams, Texture2d,
+    Sampler2d, Sampler2dParams,
 };
 
 pub struct FramebufferAttachment2d<S> {
-    pub(super) texture: Texture2d<S>,
-    pub(super) level: u32,
+    raw: raw::FramebufferAttachment2d,
+    _phantom: PhantomData<S>,
 }
 
 pub struct Framebuffer<F: Fragment<SlView>> {
-    raw: raw::Framebuffer,
+    raw: Rc<raw::Framebuffer>,
     attachments: F::GlView,
 }
 
 impl<F: Fragment<SlView>> Framebuffer<F> {}
 
+#[derive(Clone)]
 pub struct FramebufferBinding<F> {
     raw: raw::FramebufferBinding,
     _phantom: PhantomData<F>,
 }
 
 impl<S: Sample> FramebufferAttachment2d<S> {
-    pub(super) fn raw(&self) -> raw::FramebufferAttachment {
-        raw::FramebufferAttachment::Texture2d {
-            texture: self.texture.raw(),
-            level: self.level,
+    pub(super) fn from_raw(raw: raw::FramebufferAttachment2d) -> Self {
+        Self {
+            raw,
+            _phantom: PhantomData,
         }
     }
 
-    pub fn texture(&self) -> &Texture2d<S> {
-        &self.texture
+    pub fn sampler(&self, params: Sampler2dParams) -> Sampler2d<S> {
+        Sampler2d::from_raw(raw::Sampler2d {
+            texture: self.raw.texture.clone(),
+            params,
+        })
     }
 
     pub fn level(&self) -> u32 {
-        self.level
-    }
-
-    pub fn sampler(&self, params: Sampler2dParams) -> Sampler2d<S> {
-        self.texture.sampler(params)
+        self.raw.level
     }
 }
 
@@ -57,7 +57,10 @@ impl<F: Fragment<SlView>> Framebuffer<F> {
         let raw_attachments = raw_attachments(&attachments);
         let raw = context.create_framebuffer(&raw_attachments)?;
 
-        Ok(Self { raw, attachments })
+        Ok(Self {
+            raw: Rc::new(raw),
+            attachments,
+        })
     }
 
     pub fn attachments(&self) -> &F::GlView {
@@ -66,7 +69,7 @@ impl<F: Fragment<SlView>> Framebuffer<F> {
 
     pub fn binding(&self) -> FramebufferBinding<F::GlView> {
         FramebufferBinding {
-            raw: self.raw.binding(),
+            raw: raw::FramebufferBinding::Framebuffer(self.raw.clone()),
             _phantom: PhantomData,
         }
     }
@@ -88,10 +91,12 @@ impl<F: Fragment<GlView>> FramebufferBinding<F> {
 }
 
 fn raw_attachments<F: Fragment<GlView>>(attachments: &F) -> Vec<raw::FramebufferAttachment> {
-    struct Visitor<'a>(Vec<raw::FramebufferAttachment<'a>>);
-    impl<'a> FragmentVisitor<'a, GlView> for Visitor<'a> {
-        fn accept<S: Sample>(&mut self, _: &str, attachment: &'a FramebufferAttachment2d<S>) {
-            self.0.push(attachment.raw());
+    struct Visitor(Vec<raw::FramebufferAttachment>);
+    impl<'a> FragmentVisitor<'a, GlView> for Visitor {
+        fn accept<S: Sample>(&mut self, _: &str, attachment: &FramebufferAttachment2d<S>) {
+            self.0.push(raw::FramebufferAttachment::Texture2d(
+                attachment.raw.clone(),
+            ));
         }
     }
 

--- a/src/gl/framebuffer.rs
+++ b/src/gl/framebuffer.rs
@@ -63,7 +63,7 @@ impl<F: Fragment<SlView>> Framebuffer<F> {
         })
     }
 
-    pub fn attachments(&self) -> &F::GlView {
+    pub fn view(&self) -> &F::GlView {
         &self.attachments
     }
 

--- a/src/gl/framebuffer.rs
+++ b/src/gl/framebuffer.rs
@@ -11,6 +11,7 @@ use super::{
     Sampler2d, Sampler2dParams,
 };
 
+#[derive(Clone)]
 pub struct FramebufferAttachment2d<S> {
     raw: raw::FramebufferAttachment2d,
     _phantom: PhantomData<S>,

--- a/src/gl/program.rs
+++ b/src/gl/program.rs
@@ -11,7 +11,6 @@ use super::{
     UniformBufferBinding,
 };
 
-#[derive(Clone)]
 pub struct Program<U, V, F = sl::Vec4> {
     raw: Rc<raw::Program>,
     _phantom: PhantomData<(U, V, F)>,

--- a/src/gl/program.rs
+++ b/src/gl/program.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use super::{
-    raw, vertex_stream::VertexStream, DrawParams, FramebufferBinding, Texture2dBinding,
+    raw, vertex_stream::VertexStream, DrawParams, FramebufferBinding, Sampler2d,
     UniformBufferBinding,
 };
 
@@ -59,13 +59,13 @@ where
 #[derive(Default)]
 struct CollectUniforms<'a> {
     raw_uniform_buffers: Vec<&'a raw::Buffer>,
-    raw_samplers: Vec<raw::TextureBinding>,
+    raw_samplers: Vec<raw::Sampler>,
 }
 
 impl<'a> UniformVisitor<'a, GlView> for CollectUniforms<'a> {
-    fn accept_sampler2d<S: Sample>(&mut self, _: &str, sampler: &Texture2dBinding<S>) {
+    fn accept_sampler2d<S: Sample>(&mut self, _: &str, sampler: &Sampler2d<S>) {
         self.raw_samplers
-            .push(raw::TextureBinding::Texture2d(sampler.raw().clone()))
+            .push(raw::Sampler::Sampler2d(sampler.raw().clone()))
     }
 
     fn accept_block<B: Block<SlView, SlView = B>>(

--- a/src/gl/raw.rs
+++ b/src/gl/raw.rs
@@ -20,7 +20,9 @@ pub use error::{
     BufferError, ContextError, Error, FramebufferError, ProgramError, ProgramValidationError,
     TextureError, VertexArrayError,
 };
-pub use framebuffer::{Framebuffer, FramebufferAttachment, FramebufferBinding};
+pub use framebuffer::{
+    Framebuffer, FramebufferAttachment, FramebufferAttachment2d, FramebufferBinding,
+};
 pub use program::Program;
 pub use sampler_params::{Sampler2dParams, SamplerMagFilter, SamplerMinFilter};
 pub use texture::{Sampler, Sampler2d, Texture2d};

--- a/src/gl/raw.rs
+++ b/src/gl/raw.rs
@@ -23,5 +23,5 @@ pub use error::{
 pub use framebuffer::{Framebuffer, FramebufferAttachment, FramebufferBinding};
 pub use program::Program;
 pub use sampler_params::{Sampler2dParams, SamplerMagFilter, SamplerMinFilter};
-pub use texture::{Texture2d, Texture2dBinding, TextureBinding};
+pub use texture::{Sampler, Sampler2d, Texture2d};
 pub use vertex_stream::{ElementType, PrimitiveType, VertexStream};

--- a/src/gl/raw/buffer.rs
+++ b/src/gl/raw/buffer.rs
@@ -71,7 +71,7 @@ impl Buffer {
 
         buffer.set(data);
 
-        check_gl_error(&gl).map_err(BufferError::Unexpected)?;
+        check_gl_error(gl).map_err(BufferError::Unexpected)?;
 
         Ok(buffer)
     }
@@ -97,7 +97,7 @@ impl Buffer {
     }
 
     pub fn set<T: Pod>(&self, data: &[T]) {
-        let gl = &self.shared.ctx.gl();
+        let gl = self.shared.ctx.gl();
         let raw_data = bytemuck::cast_slice(data);
 
         // We can get away with always using `ARRAY_BUFFER` as the target here,

--- a/src/gl/raw/context.rs
+++ b/src/gl/raw/context.rs
@@ -24,7 +24,7 @@ pub struct Context {
 
 impl ContextShared {
     pub fn ref_eq(&self, other: &ContextShared) -> bool {
-        self as *const ContextShared == other as *const ContextShared
+        std::ptr::eq(self as *const ContextShared, other as *const ContextShared)
     }
 
     pub fn gl(&self) -> &glow::Context {

--- a/src/gl/raw/context.rs
+++ b/src/gl/raw/context.rs
@@ -13,9 +13,27 @@ use super::{
     Program, Texture2d, TextureError,
 };
 
-pub struct Context {
-    gl: Rc<glow::Context>,
+pub(super) struct ContextShared {
+    gl: glow::Context,
     caps: Caps,
+}
+
+pub struct Context {
+    shared: Rc<ContextShared>,
+}
+
+impl ContextShared {
+    pub fn ref_eq(&self, other: &ContextShared) -> bool {
+        self as *const ContextShared == other as *const ContextShared
+    }
+
+    pub fn gl(&self) -> &glow::Context {
+        &self.gl
+    }
+
+    pub fn caps(&self) -> &Caps {
+        &self.caps
+    }
 }
 
 impl Context {
@@ -31,18 +49,13 @@ impl Context {
             gl.bind_vertex_array(Some(vao));
         }
 
-        Ok(Self {
-            gl: Rc::new(gl),
-            caps,
-        })
-    }
+        let shared = Rc::new(ContextShared { gl, caps });
 
-    pub fn gl(&self) -> &Rc<glow::Context> {
-        &self.gl
+        Ok(Self { shared })
     }
 
     pub fn caps(&self) -> &Caps {
-        &self.caps
+        &self.shared.caps
     }
 
     pub fn create_buffer<T: Pod>(
@@ -50,25 +63,34 @@ impl Context {
         data: &[T],
         usage: BufferUsage,
     ) -> Result<Buffer, BufferError> {
-        Buffer::new(self.gl.clone(), data, usage)
+        Buffer::new(self.shared.clone(), data, usage)
     }
 
     pub fn create_texture_2d(&self, image: Image) -> Result<Texture2d, TextureError> {
-        Texture2d::new(self.gl.clone(), &self.caps, image)
+        Texture2d::new(self.shared.clone(), image)
     }
 
     pub fn create_texture_2d_with_mipmap(&self, image: Image) -> Result<Texture2d, TextureError> {
-        Texture2d::new_with_mipmap(self.gl.clone(), &self.caps, image)
+        Texture2d::new_with_mipmap(self.shared.clone(), image)
     }
 
     pub fn create_framebuffer(
         &self,
         attachments: &[FramebufferAttachment],
     ) -> Result<Framebuffer, FramebufferError> {
-        Framebuffer::new(self.gl.clone(), &self.caps, attachments)
+        Framebuffer::new(self.shared.clone(), attachments)
     }
 
     pub fn create_program(&self, def: ProgramDef) -> Result<Program, ProgramError> {
-        Program::new(self.gl.clone(), def)
+        Program::new(self.shared.clone(), def)
+    }
+
+    pub fn clear_color(&self, color: glam::Vec4) {
+        let gl = self.shared.gl();
+
+        unsafe {
+            gl.clear_color(color.x, color.y, color.z, color.w);
+            gl.clear(glow::COLOR_BUFFER_BIT);
+        }
     }
 }

--- a/src/gl/raw/draw_params.rs
+++ b/src/gl/raw/draw_params.rs
@@ -1,3 +1,5 @@
+use glow::HasContext;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ComparisonFunc {
     Always,
@@ -27,6 +29,7 @@ impl ComparisonFunc {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct DrawParams {
     depth_test: Option<ComparisonFunc>,
 }
@@ -34,5 +37,24 @@ pub struct DrawParams {
 impl Default for DrawParams {
     fn default() -> Self {
         Self { depth_test: None }
+    }
+}
+
+impl DrawParams {
+    pub(super) fn set_delta(&self, gl: &glow::Context, current: &DrawParams) {
+        if self.depth_test != current.depth_test {
+            if let Some(func) = self.depth_test {
+                let func = func.to_gl();
+
+                unsafe {
+                    gl.enable(glow::DEPTH_TEST);
+                    gl.depth_func(func);
+                }
+            } else {
+                unsafe {
+                    gl.disable(glow::DEPTH_TEST);
+                }
+            }
+        }
     }
 }

--- a/src/gl/raw/framebuffer.rs
+++ b/src/gl/raw/framebuffer.rs
@@ -6,7 +6,7 @@ use super::{
     context::ContextShared,
     error::{check_framebuffer_completeness, check_gl_error, FramebufferError},
     texture::Texture2dShared,
-    Caps, ImageInternalFormat, Texture2d,
+    ImageInternalFormat, Texture2d,
 };
 
 #[derive(Clone)]

--- a/src/gl/raw/framebuffer.rs
+++ b/src/gl/raw/framebuffer.rs
@@ -180,7 +180,7 @@ impl Framebuffer {
             gl.draw_buffers(&draw_buffers);
         }
 
-        let completeness = check_framebuffer_completeness(&gl);
+        let completeness = check_framebuffer_completeness(gl);
 
         unsafe {
             gl.bind_framebuffer(glow::FRAMEBUFFER, None);
@@ -188,7 +188,7 @@ impl Framebuffer {
 
         // Check for errors *after* unbinding the framebuffer.
         completeness.map_err(FramebufferError::Incomplete)?;
-        check_gl_error(&gl).map_err(FramebufferError::Unexpected)?;
+        check_gl_error(gl).map_err(FramebufferError::Unexpected)?;
 
         Ok(Framebuffer {
             shared,

--- a/src/gl/raw/program.rs
+++ b/src/gl/raw/program.rs
@@ -2,14 +2,12 @@ use std::{collections::BTreeSet, rc::Rc};
 
 use glow::HasContext;
 
-use crate::{
-    gl::ProgramError,
-    sl::program_def::{ProgramDef, UniformSamplerDef},
-};
+use crate::sl::program_def::{ProgramDef, UniformSamplerDef};
 
 use super::{
     context::ContextShared, error::check_gl_error, framebuffer::FramebufferBinding,
-    vertex_layout::VertexAttributeLayout, Buffer, ProgramValidationError, Sampler, VertexStream,
+    vertex_layout::VertexAttributeLayout, Buffer, ProgramError, ProgramValidationError, Sampler,
+    VertexStream,
 };
 
 struct ProgramShared {

--- a/src/gl/raw/program.rs
+++ b/src/gl/raw/program.rs
@@ -9,8 +9,7 @@ use crate::{
 
 use super::{
     context::ContextShared, error::check_gl_error, framebuffer::FramebufferBinding,
-    vertex_layout::VertexAttributeLayout, Buffer, ProgramValidationError, TextureBinding,
-    VertexStream,
+    vertex_layout::VertexAttributeLayout, Buffer, ProgramValidationError, Sampler, VertexStream,
 };
 
 struct ProgramShared {
@@ -138,7 +137,7 @@ impl Program {
             }
         }
 
-        check_gl_error(&gl).map_err(ProgramError::Unexpected)?;
+        check_gl_error(gl).map_err(ProgramError::Unexpected)?;
 
         Ok(Program { shared })
     }
@@ -157,7 +156,7 @@ impl Program {
     pub unsafe fn draw(
         &self,
         uniform_buffers: &[&Buffer],
-        samplers: &[TextureBinding],
+        samplers: &[Sampler],
         vertices: &VertexStream,
         framebuffer: &FramebufferBinding,
     ) {

--- a/src/gl/raw/sampler_params.rs
+++ b/src/gl/raw/sampler_params.rs
@@ -65,7 +65,9 @@ impl SamplerWrap {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Sampler2dParams {
+    // TODO: I think this should be specific to shadow samplers.
     pub comparison_func: Option<ComparisonFunc>,
+
     pub mag_filter: SamplerMagFilter,
     pub min_filter: SamplerMinFilter,
     pub wrap_s: SamplerWrap,

--- a/src/gl/raw/sampler_params.rs
+++ b/src/gl/raw/sampler_params.rs
@@ -86,7 +86,7 @@ impl Default for Sampler2dParams {
 
 impl Sampler2dParams {
     pub(super) fn set_delta(&self, gl: &glow::Context, current: &Sampler2dParams) {
-        if current.comparison_func != self.comparison_func {
+        if self.comparison_func != current.comparison_func {
             let (mode, func) = self
                 .comparison_func
                 .map_or((glow::NONE as i32, ComparisonFunc::LessOrEqual), |func| {
@@ -100,7 +100,7 @@ impl Sampler2dParams {
             }
         }
 
-        if current.mag_filter != self.mag_filter {
+        if self.mag_filter != current.mag_filter {
             let mag_filter = self.mag_filter.to_gl() as i32;
 
             unsafe {
@@ -108,7 +108,7 @@ impl Sampler2dParams {
             }
         }
 
-        if current.min_filter != self.min_filter {
+        if self.min_filter != current.min_filter {
             let min_filter = self.min_filter.to_gl() as i32;
 
             unsafe {
@@ -116,7 +116,7 @@ impl Sampler2dParams {
             }
         }
 
-        if current.wrap_s != self.wrap_s {
+        if self.wrap_s != current.wrap_s {
             let wrap_s = self.wrap_s.to_gl() as i32;
 
             unsafe {
@@ -124,7 +124,7 @@ impl Sampler2dParams {
             }
         }
 
-        if current.wrap_t != self.wrap_t {
+        if self.wrap_t != current.wrap_t {
             let wrap_t = self.wrap_t.to_gl() as i32;
 
             unsafe {

--- a/src/gl/raw/texture.rs
+++ b/src/gl/raw/texture.rs
@@ -176,18 +176,16 @@ impl Sampler {
     }
 
     pub(super) fn bind(&self) {
-        use Sampler::*;
-
         match self {
-            Sampler2d(texture) => {
-                let gl = texture.texture.ctx.gl();
-                let id = texture.texture.id;
+            Sampler::Sampler2d(Sampler2d { texture, params }) => {
+                let gl = texture.ctx.gl();
+                let id = texture.id;
 
                 unsafe {
                     gl.bind_texture(glow::TEXTURE_2D, Some(id));
                 }
 
-                texture.texture.set_sampler_params(texture.params);
+                texture.set_sampler_params(*params);
             }
         }
     }
@@ -196,8 +194,8 @@ impl Sampler {
         use Sampler::*;
 
         match self {
-            Sampler2d(texture) => {
-                let gl = texture.texture.ctx.gl();
+            Sampler2d(sampler) => {
+                let gl = sampler.texture.ctx.gl();
 
                 unsafe {
                     gl.bind_texture(glow::TEXTURE_2D, None);

--- a/src/gl/raw/texture.rs
+++ b/src/gl/raw/texture.rs
@@ -15,12 +15,12 @@ pub(super) struct Texture2dShared {
 }
 
 #[derive(Clone)]
-pub enum TextureBinding {
-    Texture2d(Texture2dBinding),
+pub enum Sampler {
+    Sampler2d(Sampler2d),
 }
 
 #[derive(Clone)]
-pub struct Texture2dBinding {
+pub struct Sampler2d {
     shared: Rc<Texture2dShared>,
     params: Sampler2dParams,
 }
@@ -121,7 +121,7 @@ impl Texture2d {
 
         // Check for errors *after* passing ownership of the texture to
         // `shared` so that it will be cleaned up if there is an error.
-        check_gl_error(&gl).map_err(TextureError::Unexpected)?;
+        check_gl_error(gl).map_err(TextureError::Unexpected)?;
 
         Ok(Texture2d { shared })
     }
@@ -152,7 +152,7 @@ impl Texture2d {
             gl.bind_texture(glow::TEXTURE_2D, None);
         }
 
-        check_gl_error(&gl).map_err(TextureError::Unexpected)?;
+        check_gl_error(gl).map_err(TextureError::Unexpected)?;
 
         Ok(texture)
     }
@@ -165,8 +165,8 @@ impl Texture2d {
         self.shared.internal_format
     }
 
-    pub fn binding(&self, params: Sampler2dParams) -> Texture2dBinding {
-        Texture2dBinding {
+    pub fn sampler(&self, params: Sampler2dParams) -> Sampler2d {
+        Sampler2d {
             shared: self.shared.clone(),
             params,
         }
@@ -208,20 +208,20 @@ fn validate_size(size: glam::UVec2, caps: &Caps) -> Result<(), TextureError> {
     Ok(())
 }
 
-impl TextureBinding {
+impl Sampler {
     pub(super) fn context(&self) -> &ContextShared {
-        use TextureBinding::*;
+        use Sampler::*;
 
         match self {
-            Texture2d(texture) => &texture.shared.ctx,
+            Sampler2d(texture) => &texture.shared.ctx,
         }
     }
 
     pub(super) fn bind(&self) {
-        use TextureBinding::*;
+        use Sampler::*;
 
         match self {
-            Texture2d(texture) => {
+            Sampler2d(texture) => {
                 let gl = texture.shared.ctx.gl();
                 let id = texture.shared.id;
 
@@ -235,10 +235,10 @@ impl TextureBinding {
     }
 
     pub(super) fn unbind(&self) {
-        use TextureBinding::*;
+        use Sampler::*;
 
         match self {
-            Texture2d(texture) => {
+            Sampler2d(texture) => {
                 let gl = texture.shared.ctx.gl();
 
                 unsafe {

--- a/src/gl/raw/vertex_stream.rs
+++ b/src/gl/raw/vertex_stream.rs
@@ -19,7 +19,7 @@ pub enum ElementType {
 }
 
 impl ElementType {
-    pub const fn to_gl(self) -> u32 {
+    pub fn to_gl(self) -> u32 {
         use ElementType::*;
 
         match self {
@@ -28,7 +28,7 @@ impl ElementType {
         }
     }
 
-    pub const fn size(self) -> usize {
+    pub fn size(self) -> usize {
         use ElementType::*;
 
         match self {

--- a/src/gl/raw/vertex_stream.rs
+++ b/src/gl/raw/vertex_stream.rs
@@ -65,15 +65,15 @@ impl PrimitiveType {
     }
 }
 
-pub struct VertexStream<'a> {
-    pub vertices: Vec<(&'a Buffer, VertexBlockDef)>,
-    pub elements: Option<(&'a Buffer, ElementType)>,
+pub struct VertexStream {
+    pub vertices: Vec<(Rc<Buffer>, VertexBlockDef)>,
+    pub elements: Option<(Rc<Buffer>, ElementType)>,
     pub primitive: PrimitiveType,
     pub range: Range<usize>,
     pub num_instances: usize,
 }
 
-impl<'a> VertexStream<'a> {
+impl VertexStream {
     pub fn is_compatible(&self, vertex_block_defs: &[VertexBlockDef]) -> bool {
         // TODO: Check vertex stream compatibility.
         true

--- a/src/gl/raw/vertex_stream.rs
+++ b/src/gl/raw/vertex_stream.rs
@@ -65,6 +65,7 @@ impl PrimitiveType {
     }
 }
 
+#[derive(Clone)]
 pub struct VertexStream {
     pub vertices: Vec<(Rc<Buffer>, VertexBlockDef)>,
     pub elements: Option<(Rc<Buffer>, ElementType)>,

--- a/src/gl/texture.rs
+++ b/src/gl/texture.rs
@@ -7,9 +7,13 @@ use super::{
     FramebufferAttachment2d,
 };
 
-#[derive(Clone)]
 pub struct Texture2d<S> {
     raw: Rc<raw::Texture2d>,
+    _phantom: PhantomData<S>,
+}
+
+pub struct Sampler2d<S> {
+    raw: raw::Sampler2d,
     _phantom: PhantomData<S>,
 }
 
@@ -26,35 +30,33 @@ impl<S: Sample> Texture2d<S> {
         }
     }
 
-    pub(super) fn raw(&self) -> &raw::Texture2d {
-        &self.raw
-    }
-
     pub fn attachment(&self) -> FramebufferAttachment2d<S> {
         self.attachment_with_level(0)
     }
 
     pub fn attachment_with_level(&self, level: u32) -> FramebufferAttachment2d<S> {
-        FramebufferAttachment2d {
-            texture: self.clone(),
+        FramebufferAttachment2d::from_raw(raw::FramebufferAttachment2d {
+            texture: self.raw.clone(),
             level,
-        }
+        })
     }
 
     pub fn sampler(&self, params: Sampler2dParams) -> Sampler2d<S> {
-        Sampler2d {
-            raw: self.raw.sampler(params),
-            _phantom: PhantomData,
-        }
+        Sampler2d::from_raw(raw::Sampler2d {
+            texture: self.raw.clone(),
+            params,
+        })
     }
 }
 
-pub struct Sampler2d<S> {
-    raw: raw::Sampler2d,
-    _phantom: PhantomData<S>,
-}
-
 impl<S> Sampler2d<S> {
+    pub(super) fn from_raw(raw: raw::Sampler2d) -> Self {
+        Self {
+            raw,
+            _phantom: PhantomData,
+        }
+    }
+
     pub fn raw(&self) -> &raw::Sampler2d {
         &self.raw
     }

--- a/src/gl/texture.rs
+++ b/src/gl/texture.rs
@@ -12,6 +12,7 @@ pub struct Texture2d<S> {
     _phantom: PhantomData<S>,
 }
 
+#[derive(Clone)]
 pub struct Sampler2d<S> {
     raw: raw::Sampler2d,
     _phantom: PhantomData<S>,

--- a/src/gl/texture.rs
+++ b/src/gl/texture.rs
@@ -41,21 +41,21 @@ impl<S: Sample> Texture2d<S> {
         }
     }
 
-    pub fn binding(&self, params: Sampler2dParams) -> Texture2dBinding<S> {
-        Texture2dBinding {
-            raw: self.raw.binding(params),
+    pub fn sampler(&self, params: Sampler2dParams) -> Sampler2d<S> {
+        Sampler2d {
+            raw: self.raw.sampler(params),
             _phantom: PhantomData,
         }
     }
 }
 
-pub struct Texture2dBinding<S> {
-    raw: raw::Texture2dBinding,
+pub struct Sampler2d<S> {
+    raw: raw::Sampler2d,
     _phantom: PhantomData<S>,
 }
 
-impl<S> Texture2dBinding<S> {
-    pub fn raw(&self) -> &raw::Texture2dBinding {
+impl<S> Sampler2d<S> {
+    pub fn raw(&self) -> &raw::Sampler2d {
         &self.raw
     }
 }

--- a/src/gl/uniform_buffer.rs
+++ b/src/gl/uniform_buffer.rs
@@ -10,7 +10,6 @@ use super::{raw, BufferUsage};
 ///
 /// Instances of `UniformBuffer` can be created with
 /// [`Context::create_uniform_buffer`](crate::gl::Context::create_uniform_buffer).
-#[derive(Clone)]
 pub struct UniformBuffer<B> {
     pub(super) raw: Rc<raw::Buffer>,
     _phantom: PhantomData<B>,

--- a/src/gl/vertex_buffer.rs
+++ b/src/gl/vertex_buffer.rs
@@ -75,6 +75,6 @@ impl<B: Block<SlView>> VertexBufferBinding<B> {
     }
 }
 
-pub(super) const fn vertex_size<V: Block<SlView>>() -> usize {
+fn vertex_size<V: Block<SlView>>() -> usize {
     std::mem::size_of::<<V::GlView as AsStd140>::Output>()
 }

--- a/src/gl/vertex_buffer.rs
+++ b/src/gl/vertex_buffer.rs
@@ -10,7 +10,6 @@ use super::{raw, BufferUsage};
 ///
 /// Instances of `VertexBuffer` can be created with
 /// [`Context::create_vertex_buffer`](crate::gl::Context::create_vertex_buffer).
-#[derive(Clone)]
 pub struct VertexBuffer<B> {
     raw: Rc<raw::Buffer>,
     _phantom: PhantomData<B>,
@@ -61,7 +60,7 @@ impl<B: Block<SlView>> VertexBuffer<B> {
 }
 
 impl<B: Block<SlView>> VertexBufferBinding<B> {
-    pub(crate) fn raw(&self) -> &raw::Buffer {
+    pub(crate) fn raw(&self) -> &Rc<raw::Buffer> {
         &self.raw
     }
 

--- a/src/interface/gl_view.rs
+++ b/src/interface/gl_view.rs
@@ -1,7 +1,7 @@
 use sealed::sealed;
 
 use crate::{
-    gl::{FramebufferAttachment2d, Texture2dBinding, UniformBufferBinding, VertexBufferBinding},
+    gl::{FramebufferAttachment2d, Sampler2d, UniformBufferBinding, VertexBufferBinding},
     internal::join_ident_path,
     sl::{self, program_def::VertexInputRate, Sample},
 };
@@ -94,7 +94,7 @@ impl<B: Block<SlView>> super::VertexField<GlView> for VertexBufferBinding<B> {}
 #[sealed]
 impl super::UniformFields for GlView {
     type Block<B: Block<SlView, SlView = B>> = UniformBufferBinding<B>;
-    type Sampler2d<S: Sample> = Texture2dBinding<S>;
+    type Sampler2d<S: Sample> = Sampler2d<S>;
     type Compose<R: Uniform<SlView>> = R::GlView;
 }
 
@@ -107,7 +107,7 @@ unsafe impl<U: Block<SlView, SlView = U>> Uniform<GlView> for UniformBufferBindi
     }
 }
 
-unsafe impl<S: Sample> Uniform<GlView> for Texture2dBinding<S> {
+unsafe impl<S: Sample> Uniform<GlView> for Sampler2d<S> {
     type GlView = Self;
     type SlView = sl::Sampler2d<S>;
 

--- a/src/interface/sl_view.rs
+++ b/src/interface/sl_view.rs
@@ -180,7 +180,7 @@ impl<B: Block<SlView, SlView = B>> UniformNonUnit for B {}
 
 unsafe impl<S: Sample> Uniform<SlView> for sl::Sampler2d<S> {
     type SlView = Self;
-    type GlView = gl::Texture2dBinding<S>;
+    type GlView = gl::Sampler2d<S>;
 
     fn visit<'a>(&'a self, path: &str, visitor: &mut impl super::UniformVisitor<'a, SlView>) {
         visitor.accept_sampler2d(path, self)


### PR DESCRIPTION
- Get rid of the internal `*Shared` types that were`Rc`-ed in `gl::raw`.
- `Rc`s are now held explicitly by `gl`.
- `raw::Program::draw` takes bindings with internal `Rc`s rather than references.
- Now, we have in both `gl::raw` and `gl`:
  - Objects are non-`Clone`.
  - Bindings are  `Clone`.