### PR TITLE
Rename `VaryingOutput` to `VertexOutput`

### DIFF
--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -17,17 +17,17 @@ mod scene_pass {
 
     use super::State;
 
-    pub fn vertex(_: (), input: sl::Vec2) -> sl::VaryingOutput<sl::Vec2> {
-        let vertex = input - sl::vec2(0.5, 0.5);
+    pub fn vertex(_: (), vertex: sl::Vec2) -> sl::VertexOutput<sl::Vec2> {
+        let vertex = vertex - sl::vec2(0.5, 0.5);
 
-        sl::VaryingOutput {
-            varying: vertex,
+        sl::VertexOutput {
             position: vertex.extend(0.0).extend(1.0),
+            varying: vertex,
         }
     }
 
-    pub fn fragment(state: State, input: sl::Vec2) -> sl::Vec4 {
-        let rg = (input + state.time).cos().pow(sl::vec2(2.0, 2.0));
+    pub fn fragment(state: State, varying: sl::Vec2) -> sl::Vec4 {
+        let rg = (varying + state.time).cos().pow(sl::vec2(2.0, 2.0));
 
         sl::vec4(rg.x, rg.y, 0.5, 1.0)
     }
@@ -50,10 +50,10 @@ mod present_pass {
         pub scene: D::ColorSampler2d<sl::Vec4>,
     }
 
-    pub fn vertex(_: (), vertex: Vertex) -> sl::VaryingOutput<sl::Vec2> {
-        sl::VaryingOutput {
-            varying: vertex.tex_coords,
+    pub fn vertex(_: (), vertex: Vertex) -> sl::VertexOutput<sl::Vec2> {
+        sl::VertexOutput {
             position: vertex.pos.extend(0.0).extend(1.0),
+            varying: vertex.tex_coords,
         }
     }
 

--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -111,7 +111,7 @@ impl Demo {
                 vertex: &self.triangle_vertices.as_vertex_spec(gl::Mode::Triangles),
                 settings: &gl::Settings::default(),
             },
-            &self.texture.as_color_attachment(),
+            self.texture.as_color_attachment(),
         )?;
 
         self.present_program.draw(
@@ -128,7 +128,7 @@ impl Demo {
                     .with_element_data(self.quad_elements.as_binding()),
                 settings: &gl::Settings::default(),
             },
-            &gl::Framebuffer::default(),
+            gl::Framebuffer::default(),
         )?;
 
         Ok(())

--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -63,7 +63,7 @@ impl Demo {
                 vertex: &self.vertices.as_vertex_spec(gl::Mode::Triangles),
                 settings: &gl::Settings::default().with_clear_color(glam::vec4(0.1, 0.2, 0.3, 1.0)),
             },
-            &gl::Framebuffer::default(),
+            gl::Framebuffer::default(),
         )
     }
 }

--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -11,17 +11,17 @@ struct Globals<D: BlockDom = Sl> {
 
 // Shader code
 
-fn vertex_shader(_: (), input: sl::Vec2) -> sl::VaryingOutput<sl::Vec2> {
-    let pos = input - sl::vec2(0.5, 0.5);
+fn vertex_shader(_: (), vertex: sl::Vec2) -> sl::VertexOutput<sl::Vec2> {
+    let pos = vertex - sl::vec2(0.5, 0.5);
 
-    sl::VaryingOutput {
-        varying: pos,
+    sl::VertexOutput {
         position: sl::vec4(pos.x, pos.y, 0.0, 1.0),
+        varying: pos,
     }
 }
 
-fn fragment_shader(uniform: Globals, input: sl::Vec2) -> sl::Vec4 {
-    let rg = (input + uniform.time).cos().pow(sl::vec2(2.0, 2.0));
+fn fragment_shader(uniform: Globals, varying: sl::Vec2) -> sl::Vec4 {
+    let rg = (varying + uniform.time).cos().pow(sl::vec2(2.0, 2.0));
 
     sl::vec4(rg.x, rg.y, 0.5, 1.0)
 }

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -80,7 +80,7 @@ impl Demo {
                     .with_clear_depth(1.0)
                     .with_depth_test(gl::Comparison::Less),
             },
-            &gl::Framebuffer::default(),
+            gl::Framebuffer::default(),
         )
     }
 }

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -30,13 +30,13 @@ struct Vertex<D: VertexDom = Sl> {
 
 // Shader code
 
-fn vertex_shader(camera: Camera, input: Vertex) -> sl::VaryingOutput<sl::Vec3> {
-    sl::VaryingOutput {
-        varying: input.instance.color,
+fn vertex_shader(camera: Camera, vertex: Vertex) -> sl::VertexOutput<sl::Vec3> {
+    sl::VertexOutput {
         position: camera.view_to_screen
             * camera.world_to_view
-            * input.instance.model_to_view
-            * input.model_pos.extend(1.0),
+            * vertex.instance.model_to_view
+            * vertex.model_pos.extend(1.0),
+        varying: vertex.instance.color,
     }
 }
 

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,5 +1,5 @@
 use posh::{
-    sl::{self, ToSl, VaryingOutput},
+    sl::{self, ToSl, VertexOutput},
     Block, BlockDom, Sl,
 };
 
@@ -25,7 +25,7 @@ struct ColorVertex<D: BlockDom = Sl> {
     flag: D::I32,
 }
 
-fn vertex_shader(globals: Globals, vertex: ColorVertex) -> VaryingOutput<sl::Vec4> {
+fn vertex_shader(globals: Globals, vertex: ColorVertex) -> VertexOutput<sl::Vec4> {
     let shift = globals.offset * globals.time;
     let shift = sl::branch(
         globals.invert.eq(2),
@@ -49,7 +49,7 @@ fn vertex_shader(globals: Globals, vertex: ColorVertex) -> VaryingOutput<sl::Vec
         sl::vec2(0.5, 0.6),
     ]);
 
-    VaryingOutput {
+    VertexOutput {
         varying: sl::Vec4::splat(0.0)
             + offsets
                 .get(globals.invert.as_u32() + 3)

--- a/examples/shadow_map.rs
+++ b/examples/shadow_map.rs
@@ -241,7 +241,7 @@ impl Demo {
                     .with_depth_test(gl::Comparison::Less)
                     .with_cull_face(gl::CullFace::Back),
             },
-            &self.light_depth_map.as_depth_attachment(),
+            self.light_depth_map.as_depth_attachment(),
         )?;
 
         self.shaded_program.draw(
@@ -261,7 +261,7 @@ impl Demo {
                     .with_depth_test(gl::Comparison::Less)
                     .with_cull_face(gl::CullFace::Back),
             },
-            &gl::Framebuffer::default(),
+            gl::Framebuffer::default(),
         )?;
 
         self.flat_program.draw(
@@ -275,7 +275,7 @@ impl Demo {
                     .with_depth_test(gl::Comparison::Less)
                     .with_cull_face(gl::CullFace::Back),
             },
-            &gl::Framebuffer::default(),
+            gl::Framebuffer::default(),
         )?;
 
         self.debug_program.draw(
@@ -289,7 +289,7 @@ impl Demo {
                     .with_element_data(self.debug_elements.as_binding()),
                 settings: &gl::Settings::default(),
             },
-            &gl::Framebuffer::default(),
+            gl::Framebuffer::default(),
         )?;
 
         Ok(())

--- a/examples/textured_cube.rs
+++ b/examples/textured_cube.rs
@@ -33,17 +33,17 @@ fn zxy(v: sl::Vec3) -> sl::Vec3 {
     sl::vec3(v.z, v.x, v.y)
 }
 
-fn vertex_shader(uniforms: Uniform, input: Vertex) -> sl::VaryingOutput<sl::Vec2> {
+fn vertex_shader(uniforms: Uniform, vertex: Vertex) -> sl::VertexOutput<sl::Vec2> {
     let camera = uniforms.camera;
     let time = uniforms.time / 3.0;
 
-    let vertex_pos = sl::vec2(input.pos.x, input.pos.y)
+    let vertex_pos = sl::vec2(vertex.pos.x, vertex.pos.y)
         .rotate(sl::Vec2::from_angle(uniforms.time))
-        .extend(input.pos.z);
+        .extend(vertex.pos.z);
     let position = camera.view_to_screen * camera.world_to_view * zxy(vertex_pos).extend(1.0);
 
-    sl::VaryingOutput {
-        varying: input.tex_coords,
+    sl::VertexOutput {
+        varying: vertex.tex_coords,
         position,
     }
 }

--- a/examples/textured_cube.rs
+++ b/examples/textured_cube.rs
@@ -108,7 +108,7 @@ impl Demo {
                     .with_clear_depth(1.0)
                     .with_depth_test(gl::Comparison::Less),
             },
-            &gl::Framebuffer::default(),
+            gl::Framebuffer::default(),
         )
     }
 }

--- a/src/gl/context.rs
+++ b/src/gl/context.rs
@@ -5,7 +5,7 @@ use crevice::std140::AsStd140;
 use crate::{
     sl::{
         transpile::transpile_to_program_def,
-        transpile::{FromFragmentInput, FromVertexInput, IntoFragmentOutput, IntoVertexOutput},
+        transpile::{FromFragmentInput, FromVertexInput, IntoFragmentOutput, IntoFullVertexOutput},
         ColorSample, Varying,
     },
     Block, Fragment, Sl, Uniform, UniformUnion, Vertex,
@@ -122,7 +122,7 @@ impl Context {
         F: Fragment<Sl>,
         W: Varying,
         InV: FromVertexInput<Vertex = V>,
-        OutW: IntoVertexOutput<Varying = W>,
+        OutW: IntoFullVertexOutput<Varying = W>,
         InW: FromFragmentInput<Varying = W>,
         OutF: IntoFragmentOutput<Fragment = F>,
     {

--- a/src/gl/framebuffer.rs
+++ b/src/gl/framebuffer.rs
@@ -36,6 +36,12 @@ impl<'a, S: ColorSample> From<&'a ColorAttachment<S>> for Framebuffer<S> {
     }
 }
 
+impl<S: ColorSample> From<ColorAttachment<S>> for Framebuffer<S> {
+    fn from(value: ColorAttachment<S>) -> Self {
+        Framebuffer(FramebufferInternal::Color(value.clone()))
+    }
+}
+
 #[derive(Clone)]
 pub struct DepthAttachment {
     raw: raw::Attachment,
@@ -53,6 +59,12 @@ impl<'a> From<&'a DepthAttachment> for Framebuffer<()> {
     }
 }
 
+impl From<DepthAttachment> for Framebuffer<()> {
+    fn from(value: DepthAttachment) -> Self {
+        Framebuffer(FramebufferInternal::Depth(value.clone()))
+    }
+}
+
 #[derive(Clone)]
 pub struct ColorDepthFramebuffer<F: Fragment<Sl>> {
     pub color: F::Gl,
@@ -61,6 +73,12 @@ pub struct ColorDepthFramebuffer<F: Fragment<Sl>> {
 
 impl<'a, F: Fragment<Sl>> From<&'a ColorDepthFramebuffer<F>> for Framebuffer<F> {
     fn from(value: &'a ColorDepthFramebuffer<F>) -> Self {
+        Framebuffer(FramebufferInternal::ColorDepth(value.clone()))
+    }
+}
+
+impl<F: Fragment<Sl>> From<ColorDepthFramebuffer<F>> for Framebuffer<F> {
+    fn from(value: ColorDepthFramebuffer<F>) -> Self {
         Framebuffer(FramebufferInternal::ColorDepth(value.clone()))
     }
 }

--- a/src/sl.rs
+++ b/src/sl.rs
@@ -33,7 +33,9 @@ pub use {
     primitives::{all, and, any, branch, or},
     sampler::{ColorSample, ColorSampler2d, ComparisonSampler2d, Sample},
     scalar::{Bool, F32, I32, U32},
-    sig::{ConstParams, FragmentInput, FragmentOutput, VaryingOutput, VertexInput, VertexOutput},
+    sig::{
+        ConstParams, FragmentInput, FragmentOutput, FullVertexOutput, VertexInput, VertexOutput,
+    },
     varying::Varying,
     vec::{
         bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, uvec2, uvec3, uvec4, vec2, vec3, vec4, BVec2,

--- a/src/sl/sig.rs
+++ b/src/sl/sig.rs
@@ -16,17 +16,17 @@ pub struct VertexInput<V> {
 
 /// Per-vertex output computed by a vertex shader.
 #[derive(Debug, Clone)]
-pub struct VertexOutput<W> {
-    pub varying: W,
+pub struct FullVertexOutput<W> {
     pub position: Vec4,
+    pub varying: W,
     pub point_size: Option<F32>,
 }
 
 /// Per-vertex position and varying output computed by a vertex shader.
 #[derive(Debug, Clone)]
-pub struct VaryingOutput<W> {
-    pub varying: W,
+pub struct VertexOutput<W> {
     pub position: Vec4,
+    pub varying: W,
 }
 
 /// Per-fragment input given to a fragment shader.

--- a/src/sl/transpile.rs
+++ b/src/sl/transpile.rs
@@ -16,7 +16,7 @@ use super::{
     primitives::value_arg,
     program_def::{ProgramDef, UniformBlockDef, UniformSamplerDef, VertexBlockDef},
     ColorSample, ColorSampler2d, ComparisonSampler2d, ConstParams, FragmentInput, FragmentOutput,
-    FullVertexOutput, Object, Varying, Vec4, VertexOutput, VertexInput, I32,
+    FullVertexOutput, Object, Varying, Vec4, VertexInput, VertexOutput, I32,
 };
 
 /// Types that can be used as vertex input for a vertex shader.

--- a/src/sl/transpile.rs
+++ b/src/sl/transpile.rs
@@ -16,7 +16,7 @@ use super::{
     primitives::value_arg,
     program_def::{ProgramDef, UniformBlockDef, UniformSamplerDef, VertexBlockDef},
     ColorSample, ColorSampler2d, ComparisonSampler2d, ConstParams, FragmentInput, FragmentOutput,
-    Object, Varying, VaryingOutput, Vec4, VertexInput, VertexOutput, I32,
+    FullVertexOutput, Object, Varying, Vec4, VertexOutput, VertexInput, I32,
 };
 
 /// Types that can be used as vertex input for a vertex shader.
@@ -43,13 +43,13 @@ impl<V: Vertex<Sl>> FromVertexInput for V {
 }
 
 /// Types that can be used as vertex output for a vertex shader.
-pub trait IntoVertexOutput {
+pub trait IntoFullVertexOutput {
     type Varying: Varying;
 
-    fn into(self) -> VertexOutput<Self::Varying>;
+    fn into(self) -> FullVertexOutput<Self::Varying>;
 }
 
-impl<W: Varying> IntoVertexOutput for VertexOutput<W> {
+impl<W: Varying> IntoFullVertexOutput for FullVertexOutput<W> {
     type Varying = W;
 
     fn into(self) -> Self {
@@ -57,11 +57,11 @@ impl<W: Varying> IntoVertexOutput for VertexOutput<W> {
     }
 }
 
-impl<V: Varying> IntoVertexOutput for VaryingOutput<V> {
+impl<V: Varying> IntoFullVertexOutput for VertexOutput<V> {
     type Varying = V;
 
-    fn into(self) -> VertexOutput<V> {
-        VertexOutput {
+    fn into(self) -> FullVertexOutput<V> {
+        FullVertexOutput {
             position: self.position,
             varying: self.varying,
             point_size: None,
@@ -69,13 +69,13 @@ impl<V: Varying> IntoVertexOutput for VaryingOutput<V> {
     }
 }
 
-impl IntoVertexOutput for Vec4 {
+impl IntoFullVertexOutput for Vec4 {
     type Varying = ();
 
-    fn into(self) -> VertexOutput<()> {
-        VertexOutput {
-            varying: (),
+    fn into(self) -> FullVertexOutput<()> {
+        FullVertexOutput {
             position: self,
+            varying: (),
             point_size: None,
         }
     }
@@ -147,7 +147,7 @@ where
     F: Fragment<Sl>,
     W: Varying,
     InV: FromVertexInput<Vertex = V>,
-    OutW: IntoVertexOutput<Varying = W>,
+    OutW: IntoFullVertexOutput<Varying = W>,
     InW: FromFragmentInput<Varying = W>,
     OutF: IntoFragmentOutput<Fragment = F>,
 {
@@ -176,7 +176,7 @@ where
     F: Fragment<Sl>,
     W: Varying,
     InV: FromVertexInput<Vertex = V>,
-    OutW: IntoVertexOutput<Varying = W>,
+    OutW: IntoFullVertexOutput<Varying = W>,
     InW: FromFragmentInput<Varying = W>,
     OutF: IntoFragmentOutput<Fragment = F>,
 {
@@ -199,7 +199,7 @@ where
     F: Fragment<Sl>,
     W: Varying,
     InV: FromVertexInput<Vertex = V>,
-    OutW: IntoVertexOutput<Varying = W>,
+    OutW: IntoFullVertexOutput<Varying = W>,
     InW: FromFragmentInput<Varying = W>,
     OutF: IntoFragmentOutput<Fragment = F>,
 {


### PR DESCRIPTION
The existing `VertexOutput` is renamed to `FullVertexOutput`, and `VaryingOutput` to `VertexOutput`.

The reason for doing this renaming is that the existing `VertexOutput` is almost never used (it only has the additional output `point_size` after all), and `VaryingOutput` feels like an awkward name.