### PR TITLE
Fix re-export of derive crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ posh-derive = { path = "derive" }
 sealed = "0.4.0"
 log = "0.4.17"
 thiserror = "1.0.38"
-bytemuck = { version = "1.12.3", features = ["derive"] }
-crevice = { version = "0.12.0" }
+bytemuck = { git = "https://github.com/leod/bytemuck", branch = "specify_crate_in_derive", features = ["derive"] }
+crevice = { git = "https://github.com/leod/crevice", branch = "specify_crate_in_derive" }
 glow = "0.11.2"
 mint = { version = "0.5.9", optional = true }
 glam = { version = "0.22.0", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -9,4 +9,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full", "visit-mut", "extra-traits"] }
+
+# Using the same version of `syn` as `bytemuck` to fix some dependency
+# resolution problem that I am too lazy to investigate.
+syn = { version = "2.0.1", features = ["full", "visit-mut", "extra-traits"] }

--- a/derive/src/block.rs
+++ b/derive/src/block.rs
@@ -131,6 +131,8 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
             ::posh::bytemuck::Pod,
             ::posh::crevice::std140::AsStd140,
         )]
+        #[bytemuck_crate(::posh::bytemuck)]
+        #[crevice_crate(::posh::crevice)]
         #(#attrs)*
         #visibility struct #helper_ident {
             #(

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,5 +1,5 @@
 use posh::{
-    sl::{self, ToSl, VertexOutput},
+    sl::{self, VertexOutput},
     Block, BlockDom, Sl,
 };
 

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -53,6 +53,12 @@ impl AsStd140 for Bool {
     }
 }
 
+impl Default for Bool {
+    fn default() -> Self {
+        false.into()
+    }
+}
+
 impl ToSl for Bool {
     type Output = sl::Bool;
 

--- a/src/gl/context.rs
+++ b/src/gl/context.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crevice::std140::AsStd140;
+use crevice::std140::{AsStd140, Std140};
 
 use crate::{
     sl::{
@@ -42,7 +42,9 @@ impl Context {
     where
         B: Block<Sl, Sl = B>,
     {
-        let raw = self.raw.create_buffer(data, glow::ARRAY_BUFFER, usage)?;
+        let raw = self
+            .raw
+            .create_buffer(bytemuck::cast_slice(data), glow::ARRAY_BUFFER, usage)?;
 
         Ok(VertexBuffer::from_raw(raw))
     }
@@ -55,9 +57,11 @@ impl Context {
     where
         E: Element,
     {
-        let raw = self
-            .raw
-            .create_buffer(data, glow::ELEMENT_ARRAY_BUFFER, usage)?;
+        let raw = self.raw.create_buffer(
+            bytemuck::cast_slice(data),
+            glow::ELEMENT_ARRAY_BUFFER,
+            usage,
+        )?;
 
         Ok(ElementBuffer::from_raw(raw))
     }
@@ -70,9 +74,9 @@ impl Context {
     where
         B: Block<Sl>,
     {
-        let raw = self
-            .raw
-            .create_buffer(&[data.as_std140()], glow::UNIFORM_BUFFER, usage)?;
+        let raw =
+            self.raw
+                .create_buffer(data.as_std140().as_bytes(), glow::UNIFORM_BUFFER, usage)?;
 
         Ok(UniformBuffer::from_raw(raw))
     }

--- a/src/gl/element_buffer.rs
+++ b/src/gl/element_buffer.rs
@@ -57,7 +57,7 @@ impl<E: Element> ElementBuffer<E> {
     }
 
     pub fn set(&self, data: &[E]) {
-        self.raw.set(data);
+        self.raw.set(bytemuck::cast_slice(data));
     }
 
     pub fn as_binding(&self) -> ElementBufferBinding {

--- a/src/gl/mat.rs
+++ b/src/gl/mat.rs
@@ -52,28 +52,6 @@ macro_rules! impl_convs {
             }
         }
 
-        impl AsStd140 for $mat {
-            type Output = crevice::std140::$mat;
-
-            fn as_std140(&self) -> Self::Output {
-                let mut output = <Self::Output as Zeroable>::zeroed();
-
-                $(
-                    output.$field_crevice = self.$field.as_std140();
-                )+
-
-                output
-            }
-
-            fn from_std140(value: Self::Output) -> Self {
-                Self {
-                    $(
-                        $field: AsStd140::from_std140(value.$field_crevice)
-                    ),+
-                }
-            }
-        }
-
         impl From<[[f32; $size]; $size]> for $mat {
             #[allow(unused)]
             fn from(value: [[f32; $size]; $size]) -> Self {
@@ -139,3 +117,68 @@ impl_convs!(
     (x_axis, y_axis, z_axis, w_axis),
     (x, y, z, w)
 );
+
+impl AsStd140 for Mat2 {
+    type Output = crevice::std140::Mat2;
+
+    fn as_std140(&self) -> Self::Output {
+        Self::Output {
+            x: self.x_axis.as_std140(),
+            _pad_x: Default::default(),
+            y: self.y_axis.as_std140(),
+            _pad_y: Default::default(),
+        }
+    }
+
+    fn from_std140(value: Self::Output) -> Self {
+        Self {
+            x_axis: AsStd140::from_std140(value.x),
+            y_axis: AsStd140::from_std140(value.y),
+        }
+    }
+}
+
+impl AsStd140 for Mat3 {
+    type Output = crevice::std140::Mat3;
+
+    fn as_std140(&self) -> Self::Output {
+        Self::Output {
+            x: self.x_axis.as_std140(),
+            _pad_x: Default::default(),
+            y: self.y_axis.as_std140(),
+            _pad_y: Default::default(),
+            z: self.z_axis.as_std140(),
+            _pad_z: Default::default(),
+        }
+    }
+
+    fn from_std140(value: Self::Output) -> Self {
+        Self {
+            x_axis: AsStd140::from_std140(value.x),
+            y_axis: AsStd140::from_std140(value.y),
+            z_axis: AsStd140::from_std140(value.z),
+        }
+    }
+}
+
+impl AsStd140 for Mat4 {
+    type Output = crevice::std140::Mat4;
+
+    fn as_std140(&self) -> Self::Output {
+        Self::Output {
+            x: self.x_axis.as_std140(),
+            y: self.y_axis.as_std140(),
+            z: self.z_axis.as_std140(),
+            w: self.w_axis.as_std140(),
+        }
+    }
+
+    fn from_std140(value: Self::Output) -> Self {
+        Self {
+            x_axis: AsStd140::from_std140(value.x),
+            y_axis: AsStd140::from_std140(value.y),
+            z_axis: AsStd140::from_std140(value.z),
+            w_axis: AsStd140::from_std140(value.w),
+        }
+    }
+}

--- a/src/gl/raw/context.rs
+++ b/src/gl/raw/context.rs
@@ -1,6 +1,5 @@
 use std::{cell::Cell, rc::Rc};
 
-use bytemuck::Pod;
 use glow::HasContext;
 
 use crate::{
@@ -93,9 +92,9 @@ impl Context {
         &self.shared.caps
     }
 
-    pub fn create_buffer<T: Pod>(
+    pub fn create_buffer(
         &self,
-        data: &[T],
+        data: &[u8],
         target: u32,
         usage: BufferUsage,
     ) -> Result<Buffer, BufferError> {

--- a/src/gl/uniform_buffer.rs
+++ b/src/gl/uniform_buffer.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, rc::Rc};
 
-use crevice::std140::AsStd140;
+use crevice::std140::{AsStd140, Std140};
 
 use crate::{Block, Sl};
 
@@ -43,7 +43,7 @@ impl<B: Block<Sl>> UniformBuffer<B> {
     }
 
     pub fn set(&self, data: B::Gl) {
-        self.raw.set(&[data.as_std140()]);
+        self.raw.set(data.as_std140().as_bytes());
 
         assert_eq!(self.raw.len() % uniform_size::<B>(), 0);
     }

--- a/src/gl/vec.rs
+++ b/src/gl/vec.rs
@@ -69,6 +69,16 @@ macro_rules! impl_vec {
             ),+
         }
 
+        impl Default for $vec {
+            fn default() -> Self {
+                Self {
+                    $(
+                        $field: Default::default()
+                    ),+
+                }
+            }
+        }
+
         impl ToSl for $vec {
             type Output = sl::$vec;
 

--- a/src/gl/vec.rs
+++ b/src/gl/vec.rs
@@ -65,7 +65,7 @@ macro_rules! impl_vec {
         #[repr(C)]
         pub struct $vec {
             $(
-                $field: $scalar
+                pub $field: $scalar
             ),+
         }
 

--- a/src/gl/vertex_buffer.rs
+++ b/src/gl/vertex_buffer.rs
@@ -49,7 +49,7 @@ where
     }
 
     pub fn set(&self, data: &[B::Gl]) {
-        self.raw.set(data);
+        self.raw.set(bytemuck::cast_slice(data));
     }
 
     pub fn as_binding(&self) -> VertexBufferBinding<B> {

--- a/src/sl/mat.rs
+++ b/src/sl/mat.rs
@@ -221,6 +221,46 @@ impl_mat!(Mat2, Vec2, (x_axis, y_axis), (X, Y));
 impl_mat!(Mat3, Vec3, (x_axis, y_axis, z_axis), (X, Y, Z));
 impl_mat!(Mat4, Vec4, (x_axis, y_axis, z_axis, w_axis), (X, Y, Z, W));
 
+#[cfg(feature = "glam")]
+impl ToSl for glam::Mat2 {
+    type Output = Mat2;
+
+    fn to_sl(self) -> Self::Output {
+        Self::Output {
+            x_axis: self.x_axis.to_sl(),
+            y_axis: self.y_axis.to_sl(),
+        }
+    }
+}
+
+#[cfg(feature = "glam")]
+impl ToSl for glam::Mat3 {
+    type Output = Mat3;
+
+    fn to_sl(self) -> Self::Output {
+        Self::Output {
+            x_axis: self.x_axis.to_sl(),
+            y_axis: self.y_axis.to_sl(),
+            z_axis: self.z_axis.to_sl(),
+        }
+    }
+}
+
+#[cfg(feature = "glam")]
+impl ToSl for glam::Mat4 {
+    type Output = Mat4;
+
+    fn to_sl(self) -> Self::Output {
+        Self::Output {
+            x_axis: self.x_axis.to_sl(),
+            y_axis: self.y_axis.to_sl(),
+            z_axis: self.y_axis.to_sl(),
+            w_axis: self.w_axis.to_sl(),
+        }
+    }
+}
+
+#[cfg(feature = "mint")]
 impl ToSl for mint::ColumnMatrix2<f32> {
     type Output = Mat2;
 
@@ -232,6 +272,7 @@ impl ToSl for mint::ColumnMatrix2<f32> {
     }
 }
 
+#[cfg(feature = "mint")]
 impl ToSl for mint::ColumnMatrix3<f32> {
     type Output = Mat3;
 
@@ -244,6 +285,7 @@ impl ToSl for mint::ColumnMatrix3<f32> {
     }
 }
 
+#[cfg(feature = "mint")]
 impl ToSl for mint::ColumnMatrix4<f32> {
     type Output = Mat4;
 

--- a/src/sl/vec.rs
+++ b/src/sl/vec.rs
@@ -58,6 +58,20 @@ macro_rules! impl_value {
 
         impl ValueNonArray for $vec {}
 
+        #[cfg(feature = "glam")]
+        impl ToSl for glam::$vec {
+            type Output = $vec;
+
+            fn to_sl(self) -> Self::Output {
+                Self::Output {
+                    $(
+                        $member: self.$member.to_sl()
+                    ),+
+                }
+            }
+        }
+
+        #[cfg(feature = "mint")]
         impl ToSl for $mint {
             type Output = $vec;
 


### PR DESCRIPTION
`posh` internally uses `bytemuck::Pod` and `crevice::std140::AsStd140` derive macros on types that are generated internally in `posh` derive macros. Currently, this only works if the user also has a dependency on `bytemuck` and `crevice`. This PR fixes this problem, such that the user dependencies are no longer needed. In order to do this, I've had to fork both `bytemuck` and `crevice` to allow specifying the crate root as a derive attribute.

The PR also adds some conversions for `Vec*` and `Mat*` that were missing.