### PR TITLE
Simplify shader function constraints

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -143,7 +143,7 @@ mod present_pass {
         glam::vec2(1., -1.),
     ];
 
-    pub fn vertex_shader(_: (), input: sl::VsInput<()>) -> sl::VsOutput<sl::Vec2> {
+    pub fn vertex_shader(input: sl::VsInput<()>) -> sl::VsOutput<sl::Vec2> {
         let position = SQUARE_POSITIONS.to_sl().get(input.vertex_id);
 
         sl::VsOutput {

--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -31,7 +31,7 @@ mod scene_pass {
 
     use super::State;
 
-    pub fn vertex_shader(_: (), vertex: sl::Vec2) -> sl::VsOutput<sl::Vec2> {
+    pub fn vertex_shader(vertex: sl::Vec2) -> sl::VsOutput<sl::Vec2> {
         let vertex = vertex - sl::vec2(0.5, 0.5);
 
         sl::VsOutput {
@@ -52,7 +52,7 @@ mod present_pass {
 
     use super::{PresentUniforms, PresentVertex};
 
-    pub fn vertex_shader(_: (), vertex: PresentVertex<Sl>) -> sl::VsOutput<sl::Vec2> {
+    pub fn vertex_shader(vertex: PresentVertex<Sl>) -> sl::VsOutput<sl::Vec2> {
         sl::VsOutput {
             clip_position: vertex.pos.extend(0.0).extend(1.0),
             interpolant: vertex.tex_coords,

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -42,7 +42,7 @@ fn vertex_shader(camera: Camera<Sl>, vertex: VsInput<Sl>) -> sl::VsOutput<sl::Ve
     }
 }
 
-fn fragment_shader(_: (), color: sl::Vec3) -> sl::Vec4 {
+fn fragment_shader(color: sl::Vec3) -> sl::Vec4 {
     color.extend(1.0)
 }
 

--- a/examples/shadertoy.rs
+++ b/examples/shadertoy.rs
@@ -27,7 +27,7 @@ const VERTICES: [glam::Vec4; 6] = [
     glam::vec4(1.0, -1.0, 0.0, 1.0),
 ];
 
-fn vertex_shader(_: (), input: sl::VsInput<()>) -> sl::Vec4 {
+fn vertex_shader(input: sl::VsInput<()>) -> sl::Vec4 {
     VERTICES.to_sl().get(input.vertex_id)
 }
 

--- a/examples/shadow_map.rs
+++ b/examples/shadow_map.rs
@@ -69,7 +69,7 @@ mod flat_pass {
         }
     }
 
-    pub fn fragment_shader(_: (), color: sl::Vec3) -> sl::Vec4 {
+    pub fn fragment_shader(color: sl::Vec3) -> sl::Vec4 {
         color.extend(1.0)
     }
 }
@@ -83,7 +83,7 @@ mod depth_pass {
         light.camera.world_to_clip(vertex.world_pos)
     }
 
-    pub fn fragment_shader(_: (), _: ()) -> () {
+    pub fn fragment_shader(_: ()) -> () {
         ()
     }
 }
@@ -163,7 +163,7 @@ mod debug_pass {
 
     use crate::ScreenVertex;
 
-    pub fn vertex_shader(_: (), vertex: ScreenVertex<Sl>) -> sl::VsOutput<sl::Vec2> {
+    pub fn vertex_shader(vertex: ScreenVertex<Sl>) -> sl::VsOutput<sl::Vec2> {
         sl::VsOutput {
             interpolant: vertex.tex_coords,
             clip_position: vertex.pos.extend(0.0).extend(1.0),

--- a/examples/test_shader_nonsense.rs
+++ b/examples/test_shader_nonsense.rs
@@ -91,11 +91,10 @@ fn vertex_shader_2(mode: sl::U32, vertex: MyVertex<Sl>) -> sl::VsOutput<MyVertex
 }
 
 fn main() {
-    let program_def =
-        posh::sl::transpile::transpile_to_program_def::<sl::U32, _, _, _, _, _, _, _, _, _>(
-            vertex_shader_2,
-            |_: (), _: MyVertex<Sl>| sl::Vec4::ZERO,
-        );
+    let program_def = posh::sl::transpile::transpile_to_program_def::<sl::U32, _, _, _, _>(
+        vertex_shader_2,
+        |_: (), _: MyVertex<Sl>| sl::Vec4::ZERO,
+    );
 
     println!("{}", program_def.vertex_shader_source);
     println!("{}", program_def.fragment_shader_source);

--- a/src/gl/context.rs
+++ b/src/gl/context.rs
@@ -3,10 +3,9 @@ use std::rc::Rc;
 use crate::{
     sl::{
         transpile::{transpile_to_program_def, transpile_to_program_def_with_consts},
-        ColorSample, Const, FromFsInput, FromVsInput, FsFunc, FsSig, Interpolant, IntoFullFsOutput,
-        IntoFullVsOutput, VsFunc, VsSig,
+        ColorSample, FsFunc, FsSig, VsFunc, VsSig,
     },
-    Block, FsInterface, Gl, Sl, UniformInterface, UniformUnion, VsInterface,
+    Block, Gl, UniformUnion,
 };
 
 use super::{

--- a/src/gl/raw/vertex_spec.rs
+++ b/src/gl/raw/vertex_spec.rs
@@ -86,7 +86,7 @@ pub struct VertexSpec {
 }
 
 impl VertexSpec {
-    pub fn is_compatible(&self, vertex_block_defs: &[VertexBlockDef]) -> bool {
+    pub fn is_compatible(&self, _vertex_block_defs: &[VertexBlockDef]) -> bool {
         // TODO: Check vertex stream compatibility. This is already ensured by
         // the typed interface on top of `raw`, but `raw` should be correct by
         // iself.

--- a/src/sl.rs
+++ b/src/sl.rs
@@ -34,7 +34,10 @@ pub use {
     primitives::{all, and, any, branch, branches, or},
     sampler::{ColorSample, ColorSampler2d, ComparisonSampler2d, Sample},
     scalar::{Bool, F32, I32, U32},
-    sig::{Const, Derivatives, FsInput, FsOutput, FullVsOutput, VsInput, VsOutput},
+    sig::{
+        Const, Derivatives, FromFsInput, FromVsInput, FsFunc, FsInput, FsSig, FullFsOutput,
+        FullVsOutput, IntoFullFsOutput, IntoFullVsOutput, VsFunc, VsInput, VsOutput, VsSig,
+    },
     vec::{
         bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, uvec2, uvec3, uvec4, vec2, vec3, vec4, BVec2,
         BVec3, BVec4, IVec2, IVec3, IVec4, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,

--- a/src/sl/sig.rs
+++ b/src/sl/sig.rs
@@ -1,6 +1,6 @@
-use crate::{Block, Gl};
+use crate::{Block, FsInterface, Gl, Sl, UniformInterface, VsInterface};
 
-use super::{dag::Expr, Bool, Value, Vec2, Vec4, F32, U32};
+use super::{dag::Expr, Bool, Interpolant, Value, Vec2, Vec4, F32, U32};
 
 /// Constants that can be passed to a shader at shader build time.
 ///
@@ -65,7 +65,319 @@ impl<W> FsInput<W> {
 
 /// Per-fragment output computed by a fragment shader.
 #[derive(Debug, Copy, Clone)]
-pub struct FsOutput<F> {
+pub struct FullFsOutput<F> {
     pub fragment: F,
     pub fragment_depth: Option<F32>,
 }
+
+/// Types that can be used as vertex input for a vertex shader.
+pub trait FromVsInput {
+    type V: VsInterface<Sl>;
+
+    fn from_vs_input(input: VsInput<Self::V>) -> Self;
+}
+
+impl<V: VsInterface<Sl>> FromVsInput for VsInput<V> {
+    type V = V;
+
+    fn from_vs_input(input: Self) -> Self {
+        input
+    }
+}
+
+impl<V: VsInterface<Sl>> FromVsInput for V {
+    type V = Self;
+
+    fn from_vs_input(input: VsInput<Self>) -> Self {
+        input.vertex
+    }
+}
+
+/// Types that can be used as vertex output for a vertex shader.
+pub trait IntoFullVsOutput {
+    type W: Interpolant;
+
+    fn into_full_vs_output(self) -> FullVsOutput<Self::W>;
+}
+
+impl<W: Interpolant> IntoFullVsOutput for FullVsOutput<W> {
+    type W = W;
+
+    fn into_full_vs_output(self) -> Self {
+        self
+    }
+}
+
+impl<V: Interpolant> IntoFullVsOutput for VsOutput<V> {
+    type W = V;
+
+    fn into_full_vs_output(self) -> FullVsOutput<V> {
+        FullVsOutput {
+            clip_position: self.clip_position,
+            interpolant: self.interpolant,
+            point_size: None,
+        }
+    }
+}
+
+impl IntoFullVsOutput for Vec4 {
+    type W = ();
+
+    fn into_full_vs_output(self) -> FullVsOutput<()> {
+        FullVsOutput {
+            clip_position: self,
+            interpolant: (),
+            point_size: None,
+        }
+    }
+}
+
+/// Types that can be used as fragment input for a fragment shader.
+pub trait FromFsInput {
+    type W: Interpolant;
+
+    fn from_fs_input(input: FsInput<Self::W>) -> Self;
+}
+
+impl<W: Interpolant> FromFsInput for FsInput<W> {
+    type W = W;
+
+    fn from_fs_input(input: Self) -> Self {
+        input
+    }
+}
+
+impl<W: Interpolant> FromFsInput for W {
+    type W = Self;
+
+    fn from_fs_input(input: FsInput<Self>) -> Self {
+        input.interpolant
+    }
+}
+
+/// Types that can be used as fragment output for a fragment shader.
+pub trait IntoFullFsOutput {
+    type F: FsInterface<Sl>;
+
+    fn into_full_fs_output(self) -> FullFsOutput<Self::F>;
+}
+
+impl<F: FsInterface<Sl>> IntoFullFsOutput for FullFsOutput<F> {
+    type F = F;
+
+    fn into_full_fs_output(self) -> Self {
+        self
+    }
+}
+
+impl<F: FsInterface<Sl>> IntoFullFsOutput for F {
+    type F = Self;
+
+    fn into_full_fs_output(self) -> FullFsOutput<Self> {
+        FullFsOutput {
+            fragment: self,
+            fragment_depth: None,
+        }
+    }
+}
+
+pub trait VsSig {
+    type C: Const;
+    type U: UniformInterface<Sl>;
+    type V: VsInterface<Sl>;
+    type W: Interpolant;
+}
+
+/// Function types that define a vertex shader.
+pub trait VsFunc<Sig: VsSig> {
+    fn call(
+        self,
+        consts: &Sig::C,
+        uniforms: Sig::U,
+        input: VsInput<Sig::V>,
+    ) -> FullVsOutput<Sig::W>;
+}
+
+macro_rules! impl_vs_func {
+    ($v:ident, $v_in:ty, $w:ident, $w_out:ty) => {
+        impl<C, U, $v, $w> VsSig for fn(&C, U, $v_in) -> $w_out
+        where
+            C: Const,
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+            W: Interpolant,
+        {
+            type C = C;
+            type U = U;
+            type V = $v;
+            type W = $w;
+        }
+
+        impl<C, U, $v, $w, Func> VsFunc<fn(&C, U, $v_in) -> $w_out> for Func
+        where
+            C: Const,
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+            W: Interpolant,
+            Func: Fn(&C, U, $v_in) -> $w_out,
+        {
+            fn call(self, consts: &C, uniforms: U, input: VsInput<$v>) -> FullVsOutput<$w> {
+                self(consts, uniforms, <$v_in>::from_vs_input(input)).into_full_vs_output()
+            }
+        }
+
+        impl<U, $v, $w> VsSig for fn(U, $v_in) -> $w_out
+        where
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+            W: Interpolant,
+        {
+            type C = ();
+            type U = U;
+            type V = $v;
+            type W = $w;
+        }
+
+        impl<U, $v, $w, Func> VsFunc<fn(U, $v_in) -> $w_out> for Func
+        where
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+            W: Interpolant,
+            Func: Fn(U, $v_in) -> $w_out,
+        {
+            fn call(self, _: &(), uniforms: U, input: VsInput<$v>) -> FullVsOutput<$w> {
+                self(uniforms, <$v_in>::from_vs_input(input)).into_full_vs_output()
+            }
+        }
+    };
+    ($v:ident, $v_in:ty) => {
+        impl<C, U, $v> VsSig for fn(&C, U, $v_in) -> Vec4
+        where
+            C: Const,
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+        {
+            type C = C;
+            type U = U;
+            type V = $v;
+            type W = ();
+        }
+
+        impl<C, U, $v, Func> VsFunc<fn(&C, U, $v_in) -> Vec4> for Func
+        where
+            C: Const,
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+            Func: Fn(&C, U, $v_in) -> Vec4,
+        {
+            fn call(self, consts: &C, uniforms: U, input: VsInput<$v>) -> FullVsOutput<()> {
+                self(consts, uniforms, <$v_in>::from_vs_input(input)).into_full_vs_output()
+            }
+        }
+
+        impl<U, $v> VsSig for fn(U, $v_in) -> Vec4
+        where
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+        {
+            type C = ();
+            type U = U;
+            type V = $v;
+            type W = ();
+        }
+
+        impl<U, $v, Func> VsFunc<fn(U, $v_in) -> Vec4> for Func
+        where
+            U: UniformInterface<Sl>,
+            V: VsInterface<Sl>,
+            Func: Fn(U, $v_in) -> Vec4,
+        {
+            fn call(self, _: &(), uniforms: U, input: VsInput<$v>) -> FullVsOutput<()> {
+                self(uniforms, <$v_in>::from_vs_input(input)).into_full_vs_output()
+            }
+        }
+    };
+}
+
+impl_vs_func!(V, V);
+impl_vs_func!(V, VsInput<V>);
+impl_vs_func!(V, V, W, VsOutput<W>);
+impl_vs_func!(V, VsInput<V>, W, VsOutput<W>);
+impl_vs_func!(V, V, W, FullVsOutput<W>);
+impl_vs_func!(V, VsInput<V>, W, FullVsOutput<W>);
+
+pub trait FsSig {
+    type C: Const;
+    type U: UniformInterface<Sl>;
+    type W: Interpolant;
+    type F: FsInterface<Sl>;
+}
+
+/// Function types that define a fragment shader.
+pub trait FsFunc<Sig: FsSig> {
+    fn call(
+        self,
+        consts: &Sig::C,
+        uniforms: Sig::U,
+        input: FsInput<Sig::W>,
+    ) -> FullFsOutput<Sig::F>;
+}
+
+macro_rules! impl_fs_func {
+    ($w:ident, $w_in:ty, $f:ident, $f_out:ty) => {
+        impl<C, U, $w, $f> FsSig for fn(&C, U, $w_in) -> $f_out
+        where
+            C: Const,
+            U: UniformInterface<Sl>,
+            W: Interpolant,
+            F: FsInterface<Sl>,
+        {
+            type C = C;
+            type U = U;
+            type W = $w;
+            type F = $f;
+        }
+
+        impl<C, U, $w, $f, Func> FsFunc<fn(&C, U, $w_in) -> $f_out> for Func
+        where
+            C: Const,
+            U: UniformInterface<Sl>,
+            W: Interpolant,
+            F: FsInterface<Sl>,
+            Func: Fn(&C, U, $w_in) -> $f_out,
+        {
+            fn call(self, consts: &C, uniforms: U, input: FsInput<$w>) -> FullFsOutput<$f> {
+                self(consts, uniforms, <$w_in>::from_fs_input(input)).into_full_fs_output()
+            }
+        }
+
+        impl<U, $w, $f> FsSig for fn(U, $w_in) -> $f_out
+        where
+            U: UniformInterface<Sl>,
+            W: Interpolant,
+            F: FsInterface<Sl>,
+        {
+            type C = ();
+            type U = U;
+            type W = $w;
+            type F = $f;
+        }
+
+        impl<U, $w, $f, Func> FsFunc<fn(U, $w_in) -> $f_out> for Func
+        where
+            U: UniformInterface<Sl>,
+            W: Interpolant,
+            F: FsInterface<Sl>,
+            Func: Fn(U, $w_in) -> $f_out,
+        {
+            fn call(self, _: &(), uniforms: U, input: FsInput<$w>) -> FullFsOutput<$f> {
+                self(uniforms, <$w_in>::from_fs_input(input)).into_full_fs_output()
+            }
+        }
+    };
+}
+
+impl_fs_func!(W, W, F, F);
+impl_fs_func!(W, W, F, FullFsOutput<F>);
+impl_fs_func!(W, FsInput<W>, F, F);
+impl_fs_func!(W, FsInput<W>, F, FullFsOutput<F>);

--- a/src/sl/sig.rs
+++ b/src/sl/sig.rs
@@ -249,6 +249,28 @@ macro_rules! impl_vs_func {
                 self(uniforms, <$v_in>::from_vs_input(input)).into_full_vs_output()
             }
         }
+
+        impl<$v, $w> VsSig for fn($v_in) -> $w_out
+        where
+            V: VsInterface<Sl>,
+            W: Interpolant,
+        {
+            type C = ();
+            type U = ();
+            type V = $v;
+            type W = $w;
+        }
+
+        impl<$v, $w, Func> VsFunc<fn($v_in) -> $w_out> for Func
+        where
+            V: VsInterface<Sl>,
+            W: Interpolant,
+            Func: Fn($v_in) -> $w_out,
+        {
+            fn call(self, _: &(), _: (), input: VsInput<$v>) -> FullVsOutput<$w> {
+                self(<$v_in>::from_vs_input(input)).into_full_vs_output()
+            }
+        }
     };
     ($v:ident, $v_in:ty) => {
         impl<C, U, $v> VsSig for fn(&C, U, $v_in) -> Vec4
@@ -294,6 +316,26 @@ macro_rules! impl_vs_func {
         {
             fn call(self, _: &(), uniforms: U, input: VsInput<$v>) -> FullVsOutput<()> {
                 self(uniforms, <$v_in>::from_vs_input(input)).into_full_vs_output()
+            }
+        }
+
+        impl<$v> VsSig for fn($v_in) -> Vec4
+        where
+            V: VsInterface<Sl>,
+        {
+            type C = ();
+            type U = ();
+            type V = $v;
+            type W = ();
+        }
+
+        impl<$v, Func> VsFunc<fn($v_in) -> Vec4> for Func
+        where
+            V: VsInterface<Sl>,
+            Func: Fn($v_in) -> Vec4,
+        {
+            fn call(self, _: &(), _: (), input: VsInput<$v>) -> FullVsOutput<()> {
+                self(<$v_in>::from_vs_input(input)).into_full_vs_output()
             }
         }
     };
@@ -372,6 +414,28 @@ macro_rules! impl_fs_func {
         {
             fn call(self, _: &(), uniforms: U, input: FsInput<$w>) -> FullFsOutput<$f> {
                 self(uniforms, <$w_in>::from_fs_input(input)).into_full_fs_output()
+            }
+        }
+
+        impl<$w, $f> FsSig for fn($w_in) -> $f_out
+        where
+            W: Interpolant,
+            F: FsInterface<Sl>,
+        {
+            type C = ();
+            type U = ();
+            type W = $w;
+            type F = $f;
+        }
+
+        impl<$w, $f, Func> FsFunc<fn($w_in) -> $f_out> for Func
+        where
+            W: Interpolant,
+            F: FsInterface<Sl>,
+            Func: Fn($w_in) -> $f_out,
+        {
+            fn call(self, _: &(), _: (), input: FsInput<$w>) -> FullFsOutput<$f> {
+                self(<$w_in>::from_fs_input(input)).into_full_fs_output()
             }
         }
     };


### PR DESCRIPTION
This is meant to simplify the traits on program creation functions.

We previously only allowed function pointer types as shader functions. Now, we except all types that implement `Fn(...) -> ...`.

As a result, we're also able to allow omitting the uniform type if it is `()`, which is nice.