### PR TITLE
Add web support to some examples

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+run-wasm = "run --release --package run-wasm -- --port 3000 --host 0.0.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ glam = { version = "0.22.0", optional = true }
 fxhash = "0.2"
 
 [workspace]
-members = ["derive"]
+members = ["derive", "run-wasm"]
 
 [features]
 # FIXME: These features are enabled by default only for testing.
@@ -27,5 +27,23 @@ default = ["glam", "mint"]
 glam = { version = "0.22.0" }
 image = "0.24.5"
 nanorand = "0.7.0"
-sdl2 = "0.35.2"
 simple_logger = "4.1.0"
+instant = "0.1.12"
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+sdl2 = "0.35.2"
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+console_log = "1"
+winit = "0.28.6"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4.37"
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies.web-sys]
+version = "0.3.22"
+features = [
+    'CanvasRenderingContext2d',
+    'Screen',
+    'ScreenOrientation',
+    'OrientationLockType',
+]

--- a/examples/shadertoy.rs
+++ b/examples/shadertoy.rs
@@ -1,6 +1,9 @@
-// From <https://www.shadertoy.com/view/mtyGWy>, created by kishimisu in 2023-05-20.
+// Converted from <https://www.shadertoy.com/view/mtyGWy>, created by kishimisu
+// on 2023-05-20.
 
-use std::time::Instant;
+mod utils;
+
+use instant::Instant;
 
 use posh::{gl, sl, Block, BlockDom, Gl, Sl, ToSl};
 
@@ -85,7 +88,7 @@ impl Demo {
         })
     }
 
-    pub fn draw(&self) -> Result<(), gl::DrawError> {
+    pub fn draw(&mut self) -> Result<(), gl::DrawError> {
         self.globals.set(Globals {
             time: Instant::now().duration_since(self.start_time).as_secs_f32(),
             resolution: [SCREEN_WIDTH, SCREEN_HEIGHT].into(),
@@ -103,43 +106,17 @@ impl Demo {
     }
 }
 
-// SDL glue
+// Platform glue
 
 fn main() {
-    simple_logger::init().unwrap();
+    utils::run_demo("Shadertoy", Demo::new, Demo::draw);
+}
 
-    let sdl = sdl2::init().unwrap();
-    let video = sdl.video().unwrap();
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub async fn run() {
+    utils::init_wasm().await;
 
-    let gl_attr = video.gl_attr();
-    gl_attr.set_context_profile(sdl2::video::GLProfile::GLES);
-    gl_attr.set_context_version(3, 0);
-
-    let window = video
-        .window("Shadertoy example", SCREEN_WIDTH, SCREEN_HEIGHT)
-        .opengl()
-        .build()
-        .unwrap();
-
-    let _gl_context = window.gl_create_context().unwrap();
-    let gl = unsafe {
-        glow::Context::from_loader_function(|s| video.gl_get_proc_address(s) as *const _)
-    };
-    let gl = gl::Context::new(gl).unwrap();
-    let demo = Demo::new(gl).unwrap();
-
-    let mut event_loop = sdl.event_pump().unwrap();
-
-    loop {
-        for event in event_loop.poll_iter() {
-            use sdl2::event::Event::*;
-
-            if matches!(event, Quit { .. }) {
-                return;
-            }
-        }
-
-        demo.draw().unwrap();
-        window.gl_swap_window();
-    }
+    #[allow(clippy::main_recursion)]
+    main();
 }

--- a/examples/shadow_map.rs
+++ b/examples/shadow_map.rs
@@ -1,5 +1,6 @@
-use std::time::Instant;
+mod utils;
 
+use instant::Instant;
 use nanorand::{Rng, WyRand};
 
 use posh::{gl, sl, Block, BlockDom, Gl, Sl, UniformInterface, UniformInterfaceDom};
@@ -466,43 +467,17 @@ fn debug_elements() -> Vec<u32> {
     vec![0, 1, 2, 0, 2, 3]
 }
 
-// SDL glue
+// Platform glue
 
 fn main() {
-    simple_logger::init().unwrap();
+    utils::run_demo("Simple shadow mapping", Demo::new, Demo::draw);
+}
 
-    let sdl = sdl2::init().unwrap();
-    let video = sdl.video().unwrap();
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub async fn run() {
+    utils::init_wasm().await;
 
-    let gl_attr = video.gl_attr();
-    gl_attr.set_context_profile(sdl2::video::GLProfile::GLES);
-    gl_attr.set_context_version(3, 0);
-
-    let window = video
-        .window("Simple shadow mapping", SCREEN_WIDTH, SCREEN_HEIGHT)
-        .opengl()
-        .build()
-        .unwrap();
-
-    let _gl_context = window.gl_create_context().unwrap();
-    let gl = unsafe {
-        glow::Context::from_loader_function(|s| video.gl_get_proc_address(s) as *const _)
-    };
-    let gl = gl::Context::new(gl).unwrap();
-    let mut demo = Demo::new(gl).unwrap();
-
-    let mut event_loop = sdl.event_pump().unwrap();
-
-    loop {
-        for event in event_loop.poll_iter() {
-            use sdl2::event::Event::*;
-
-            if matches!(event, Quit { .. }) {
-                return;
-            }
-        }
-
-        demo.draw().unwrap();
-        window.gl_swap_window();
-    }
+    #[allow(clippy::main_recursion)]
+    main();
 }

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -1,0 +1,134 @@
+use posh::gl;
+
+#[cfg(target_family = "wasm")]
+pub fn run_demo<Demo: 'static>(
+    demo_name: &str,
+    demo_new: fn(gl::Context) -> Result<Demo, gl::CreateError>,
+    demo_draw: fn(&mut Demo) -> Result<(), gl::DrawError>,
+) {
+    use wasm_bindgen::JsCast;
+    use winit::{
+        dpi::LogicalSize,
+        event::{Event, WindowEvent},
+        event_loop::EventLoop,
+        platform::web::WindowExtWebSys,
+        window::WindowBuilder,
+    };
+
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title(&format!("posh demo: {demo_name}"))
+        .with_inner_size(LogicalSize::new(400.0, 200.0))
+        .build(&event_loop)
+        .unwrap();
+
+    let canvas = window.canvas();
+
+    web_sys::window()
+        .unwrap()
+        .document()
+        .unwrap()
+        .body()
+        .unwrap()
+        .append_child(&canvas)
+        .unwrap();
+
+    let webgl2_context = window
+        .canvas()
+        .get_context("webgl2")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<web_sys::WebGl2RenderingContext>()
+        .unwrap();
+    let gl = glow::Context::from_webgl2_context(webgl2_context);
+    let gl = gl::Context::new(gl).unwrap();
+
+    let mut demo = demo_new(gl).unwrap();
+
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            window_id,
+        } if window_id == window.id() => control_flow.set_exit(),
+        Event::MainEventsCleared => {
+            window.request_redraw();
+        }
+        Event::RedrawRequested(_) => {
+            demo_draw(&mut demo).unwrap();
+        }
+        _ => (),
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub fn run_demo<Demo: 'static>(
+    demo_name: &str,
+    demo_new: fn(gl::Context) -> Result<Demo, gl::CreateError>,
+    demo_draw: fn(&mut Demo) -> Result<(), gl::DrawError>,
+) {
+    simple_logger::init().unwrap();
+
+    let sdl = sdl2::init().unwrap();
+    let video = sdl.video().unwrap();
+
+    let gl_attr = video.gl_attr();
+    gl_attr.set_context_profile(sdl2::video::GLProfile::GLES);
+    gl_attr.set_context_version(3, 0);
+
+    let window = video
+        .window(&format!("posh demo: {demo_name}"), 1024, 768)
+        .opengl()
+        .build()
+        .unwrap();
+
+    let _gl_context = window.gl_create_context().unwrap();
+    let gl = unsafe {
+        glow::Context::from_loader_function(|s| video.gl_get_proc_address(s) as *const _)
+    };
+    let gl = gl::Context::new(gl).unwrap();
+    let mut demo = demo_new(gl).unwrap();
+
+    let mut event_loop = sdl.event_pump().unwrap();
+
+    loop {
+        for event in event_loop.poll_iter() {
+            use sdl2::event::Event::*;
+
+            match event {
+                Quit { .. } => return,
+                _ => {}
+            }
+        }
+
+        demo_draw(&mut demo).unwrap();
+        window.gl_swap_window();
+    }
+}
+
+#[cfg(target_family = "wasm")]
+pub async fn init_wasm() {
+    use wasm_bindgen_futures::JsFuture;
+
+    console_log::init_with_level(log::Level::Debug).expect("error initializing logger");
+
+    // Orientation locking seems to be a new feature, so this might not work on
+    // many (any?) devices.
+    match web_sys::window()
+        .unwrap()
+        .screen()
+        .unwrap()
+        .orientation()
+        .lock(web_sys::OrientationLockType::Landscape)
+    {
+        Ok(promise) => {
+            let result = JsFuture::from(promise).await;
+            if let Err(error) = result {
+                log::info!("Failed to lock orientation: {:?}", error);
+            }
+        }
+        Err(error) => {
+            log::info!("Failed to create lock promise: {:?}", error);
+        }
+    }
+}

--- a/run-wasm/Cargo.toml
+++ b/run-wasm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "run-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cargo-run-wasm = "0.3.0"

--- a/run-wasm/src/main.rs
+++ b/run-wasm/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
+}


### PR DESCRIPTION
I did not convert the `textured_cube` and `instancing` examples to have web support, since those read data from files and I did not feel like tackling that that for web.