### PR TITLE
Require `Default` for most associated types of `BlockDom`

### DIFF
--- a/src/interface/block.rs
+++ b/src/interface/block.rs
@@ -16,17 +16,17 @@ pub trait BlockDom: Copy {
     /// A floating-point value.
     ///
     /// Has [`f32`] as its physical view and [`sl::F32`] as its logical view.
-    type F32: Block<Self> + ToSl<Output = sl::F32>;
+    type F32: Block<Self> + ToSl<Output = sl::F32> + Default;
 
     /// A signed integer value.
     ///
     /// Has [`i32`] as its physical view and [`sl::I32`] as its logical view.
-    type I32: Block<Self> + ToSl<Output = sl::I32>;
+    type I32: Block<Self> + ToSl<Output = sl::I32> + Default;
 
     /// An unsigned integer value.
     ///
     /// Has [`u32`] as its physical view and [`sl::U32`] as its logical view.
-    type U32: Block<Self> + ToSl<Output = sl::U32>;
+    type U32: Block<Self> + ToSl<Output = sl::U32> + Default;
 
     /// A boolean value.
     ///
@@ -40,55 +40,55 @@ pub trait BlockDom: Copy {
     ///
     /// Has [`gl::Vec2`](crate::gl::Vec2) as its physical view and [`sl::Vec2`]
     /// as its logical view.
-    type Vec2: Block<Self> + ToSl<Output = sl::Vec2>;
+    type Vec2: Block<Self> + ToSl<Output = sl::Vec2> + Default;
 
     /// A three-dimensional floating-point vector.
     ///
     /// Has [`gl::Vec3`](crate::gl::Vec3) as its physical view and [`sl::Vec3`]
     /// as its logical view.
-    type Vec3: Block<Self> + ToSl<Output = sl::Vec3>;
+    type Vec3: Block<Self> + ToSl<Output = sl::Vec3> + Default;
 
     /// A four-dimensional floating-point vector.
     ///
     /// Has [`gl::Vec4`](crate::gl::Vec4) as its physical view and [`sl::Vec4`]
     /// as its logical view.
-    type Vec4: Block<Self> + ToSl<Output = sl::Vec4>;
+    type Vec4: Block<Self> + ToSl<Output = sl::Vec4> + Default;
 
     /// A two-dimensional signed integer vector.
     ///
     /// Has [`gl::IVec2`](crate::gl::IVec2) as its physical view and
     /// [`sl::IVec2`] as its logical view.
-    type IVec2: Block<Self> + ToSl<Output = sl::IVec2>;
+    type IVec2: Block<Self> + ToSl<Output = sl::IVec2> + Default;
 
     /// A three-dimensional signed integer vector.
     ///
     /// Has [`gl::IVec3`](crate::gl::IVec3) as its physical view and
     /// [`sl::IVec3`] as its logical view.
-    type IVec3: Block<Self> + ToSl<Output = sl::IVec3>;
+    type IVec3: Block<Self> + ToSl<Output = sl::IVec3> + Default;
 
     /// A four-dimensional signed integer vector.
     ///
     /// Has [`gl::IVec4`](crate::gl::IVec4) as its physical view and
     /// [`sl::IVec4`] as its logical view.
-    type IVec4: Block<Self> + ToSl<Output = sl::IVec4>;
+    type IVec4: Block<Self> + ToSl<Output = sl::IVec4> + Default;
 
     /// A two-dimensional unsigned integer vector.
     ///
     /// Has [`gl::UVec2`](crate::gl::UVec2) as its physical view and
     /// [`sl::UVec2`] as its logical view.
-    type UVec2: Block<Self> + ToSl<Output = sl::UVec2>;
+    type UVec2: Block<Self> + ToSl<Output = sl::UVec2> + Default;
 
     /// A three-dimensional unsigned integer vector.
     ///
     /// Has [`gl::UVec3`](crate::gl::UVec3) as its physical view and
     /// [`sl::UVec3`] as its logical view.
-    type UVec3: Block<Self> + ToSl<Output = sl::UVec3>;
+    type UVec3: Block<Self> + ToSl<Output = sl::UVec3> + Default;
 
     /// A four-dimensional unsigned integer vector.
     ///
     /// Has [`gl::UVec4`](crate::gl::UVec4) as its physical view and
     /// [`sl::UVec4`] as its logical view.
-    type UVec4: Block<Self> + ToSl<Output = sl::UVec4>;
+    type UVec4: Block<Self> + ToSl<Output = sl::UVec4> + Default;
 
     /// A two-by-two floating-point matrix.
     ///


### PR DESCRIPTION
This is so to make it easier to derive `Default` for user-defined block structs.