### PR TITLE
Frame time tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bytemuck = { git = "https://github.com/leod/bytemuck", branch = "specify_crate_i
 crevice = { git = "https://github.com/leod/crevice", branch = "specify_crate_in_derive" }
 fxhash = "0.2"
 glam = { version = "0.27.0", optional = true }
-glow = "0.13.0"
+glow = { git = "https://github.com/grovesNL/glow", rev = "aa4238a60d17076b917eaa1ec662e5080df42b0a" }
 log = "0.4.17"
 mint = { version = "0.5.9", optional = true }
 sealed = "0.4.0"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -18,10 +18,10 @@ use crevice::std140::AsStd140;
 
 use crate::{sl, ToSl};
 
-pub use self::image::{ColorImage, DepthImage};
 pub use context::{CacheDrawBuilder, Context};
 pub use element_buffer::{Element, ElementBuffer, ElementBufferBinding};
 pub use framebuffer::{ColorAttachment, DepthAttachment, Framebuffer};
+pub use image::{ColorImage, DepthImage};
 pub use mat::{Mat2, Mat3, Mat4};
 pub use program::{
     DrawBuilder, DrawBuilderWithFramebuffer, DrawBuilderWithUniforms,
@@ -29,10 +29,10 @@ pub use program::{
 };
 pub use raw::{
     BlendEquation, BlendFunc, Blending, BufferError, BufferUsage, Caps, ClearParams, Comparison,
-    ContextError, CreateError, CullFace, DrawError, DrawParams, ElementType, FramebufferError,
-    ImageFormat, ImageInternalFormat, PrimitiveMode, ProgramError, ProgramValidationError, Rect,
-    Sampler2dParams, SamplerMagFilter, SamplerMinFilter, SamplerWrap, StencilOp, StencilOps,
-    StencilTest, TextureError, VertexArrayError,
+    ContextError, CreateError, CullFace, DrawError, DrawParams, ElementType, FrameTrace,
+    FramebufferError, ImageFormat, ImageInternalFormat, PrimitiveMode, ProgramError,
+    ProgramValidationError, Rect, Sampler2dParams, SamplerMagFilter, SamplerMinFilter, SamplerWrap,
+    StencilOp, StencilOps, StencilTest, TextureError, TracingConfig, VertexArrayError,
 };
 pub use texture::{ColorSampler2d, ColorTexture2d, ComparisonSampler2d, DepthTexture2d};
 pub use uniform_buffer::{UniformBuffer, UniformBufferBinding};

--- a/src/gl/context.rs
+++ b/src/gl/context.rs
@@ -1,6 +1,6 @@
 use std::{
     any::{type_name, TypeId},
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::hash_map,
     marker::PhantomData,
     rc::Rc,
@@ -113,7 +113,7 @@ where
                 &self.gl.raw,
                 self.vertex_shader,
                 self.fragment_shader,
-                *self.gl.enable_program_source_logging.borrow(),
+                self.gl.enable_program_source_logging.get(),
             );
 
         let inner = DrawBuilder {
@@ -135,7 +135,7 @@ where
 pub struct Context {
     raw: Rc<raw::Context>,
     program_cache: Rc<RefCell<ProgramCache>>,
-    enable_program_source_logging: Rc<RefCell<bool>>,
+    enable_program_source_logging: Rc<Cell<bool>>,
 }
 
 impl Context {
@@ -240,7 +240,7 @@ impl Context {
         let program_def =
             transpile_to_program_def::<U, VSig, VFunc, FSig, FFunc>(vertex_shader, fragment_shader);
 
-        if *self.enable_program_source_logging.borrow() {
+        if self.enable_program_source_logging.get() {
             log::info!("Vertex shader:\n{}", program_def.vertex_shader_source);
             log::info!("Fragment shader:\n{}", program_def.fragment_shader_source);
         }
@@ -269,7 +269,7 @@ impl Context {
             fragment_shader,
         );
 
-        if *self.enable_program_source_logging.borrow() {
+        if self.enable_program_source_logging.get() {
             log::info!("Vertex shader:\n{}", program_def.vertex_shader_source);
             log::info!("Fragment shader:\n{}", program_def.fragment_shader_source);
         }
@@ -311,7 +311,7 @@ impl Context {
     }
 
     pub fn set_enable_program_source_logging(&self, value: bool) {
-        *self.enable_program_source_logging.borrow_mut() = value;
+        self.enable_program_source_logging.set(value);
     }
 
     pub fn clear<F: FsInterface<Sl>>(

--- a/src/gl/context.rs
+++ b/src/gl/context.rs
@@ -19,8 +19,9 @@ use crate::{
 use super::{
     program::{DrawBuilder, DrawBuilderWithUniforms},
     raw, BufferError, BufferUsage, Caps, ClearParams, ColorImage, ColorTexture2d, ContextError,
-    CreateError, DepthImage, DepthTexture2d, DrawError, Element, ElementBuffer, Framebuffer,
-    FramebufferError, Program, ProgramError, TextureError, UniformBuffer, VertexBuffer,
+    CreateError, DepthImage, DepthTexture2d, DrawError, Element, ElementBuffer, FrameTrace,
+    Framebuffer, FramebufferError, Program, ProgramError, TextureError, TracingConfig,
+    UniformBuffer, VertexBuffer,
 };
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -319,5 +320,17 @@ impl Context {
         params: ClearParams,
     ) -> Result<(), FramebufferError> {
         self.raw.clear(&framebuffer.into().raw(), params)
+    }
+
+    pub fn set_tracing_config(&self, config: Option<TracingConfig>) {
+        self.raw.set_tracing_config(config);
+    }
+
+    pub fn tracing_start_frame(&self) -> Option<FrameTrace> {
+        self.raw.tracing_start_frame()
+    }
+
+    pub fn tracing_stop_frame(&self) {
+        self.raw.tracing_stop_frame()
     }
 }

--- a/src/gl/raw.rs
+++ b/src/gl/raw.rs
@@ -1,6 +1,7 @@
 mod buffer;
 mod caps;
 mod context;
+mod disjoint_timer_query;
 mod error;
 mod framebuffer;
 mod image;
@@ -8,10 +9,10 @@ mod params;
 mod program;
 mod sampler_params;
 mod texture;
+mod tracing;
 mod vertex_layout;
 mod vertex_spec;
 
-pub use self::image::{Image, ImageComponentType, ImageFormat, ImageInternalFormat};
 pub use buffer::{Buffer, BufferUsage};
 pub use caps::Caps;
 pub use context::Context;
@@ -20,6 +21,7 @@ pub use error::{
     ProgramValidationError, TextureError, VertexArrayError,
 };
 pub use framebuffer::{Attachment, AttachmentVec, Framebuffer};
+pub use image::{Image, ImageComponentType, ImageFormat, ImageInternalFormat};
 pub use params::{
     BlendEquation, BlendFunc, Blending, ClearParams, Comparison, CullFace, DrawParams, Rect,
     StencilOp, StencilOps, StencilTest,
@@ -27,6 +29,7 @@ pub use params::{
 pub use program::Program;
 pub use sampler_params::{Sampler2dParams, SamplerMagFilter, SamplerMinFilter, SamplerWrap};
 pub use texture::{Sampler, Sampler2d, Texture2d};
+pub use tracing::{FrameTrace, TracingConfig};
 pub use vertex_spec::{
     ElementType, PrimitiveMode, VertexBufferBinding, VertexBufferBindingVec, VertexSpec,
 };

--- a/src/gl/raw/caps.rs
+++ b/src/gl/raw/caps.rs
@@ -5,6 +5,7 @@ pub struct Caps {
     pub max_texture_size: u32,
     pub max_color_attachments: u32,
     pub max_draw_buffers: u32,
+    pub disjoint_timer_query_webgl2: bool,
 }
 
 impl Caps {
@@ -21,6 +22,9 @@ impl Caps {
             max_texture_size: max_texture_size.try_into().unwrap(),
             max_color_attachments: max_color_attachments.try_into().unwrap(),
             max_draw_buffers: max_draw_buffers.try_into().unwrap(),
+            disjoint_timer_query_webgl2: gl
+                .supported_extensions()
+                .contains("EXT_disjoint_timer_query_webgl2"),
         }
     }
 }

--- a/src/gl/raw/context.rs
+++ b/src/gl/raw/context.rs
@@ -249,7 +249,7 @@ impl ContextShared {
 
         if bound_ids.len() <= unit {
             let diff = unit - bound_ids.len() + 1;
-            bound_ids.extend(std::iter::repeat(None).take(diff));
+            bound_ids.extend(std::iter::repeat_n(None, diff));
         }
 
         if bound_ids[unit] == id {
@@ -287,12 +287,7 @@ impl ContextShared {
             self.bound_depth_attachment_id.set(None);
         }
 
-        if self
-            .bound_color_attachment_ids
-            .borrow()
-            .iter()
-            .any(|bound_id| *bound_id == id)
-        {
+        if self.bound_color_attachment_ids.borrow().contains(&id) {
             self.bind_draw_fbo(true);
 
             // TODO: We could be more efficient in how much we unbind here, but
@@ -360,7 +355,7 @@ impl ContextShared {
 
         if bound_ids.len() <= location as usize {
             let diff = location as usize - bound_ids.len() + 1;
-            bound_ids.extend(std::iter::repeat(None).take(diff));
+            bound_ids.extend(std::iter::repeat_n(None, diff));
         }
 
         if bound_ids[location as usize] == id {

--- a/src/gl/raw/disjoint_timer_query.rs
+++ b/src/gl/raw/disjoint_timer_query.rs
@@ -1,0 +1,85 @@
+use std::{
+    rc::{Rc, Weak},
+    time::Duration,
+};
+
+use glow::HasContext;
+
+use super::{context::ContextShared, error::QueryError};
+
+pub(super) struct DisjointTimerQuery {
+    // `ctx` is a weak pointer to prevent a cycle between `ContextShared` and
+    // `Tracing`.
+    ctx: Weak<ContextShared>,
+    id: glow::Query,
+}
+
+impl DisjointTimerQuery {
+    pub fn new(ctx: &Rc<ContextShared>) -> Result<Self, QueryError> {
+        if !ctx.caps().disjoint_timer_query_webgl2 {
+            return Err(QueryError::Unsupported);
+        }
+
+        let gl = ctx.gl();
+        let id = unsafe { gl.create_query() }.map_err(QueryError::ObjectCreation)?;
+
+        #[cfg(debug_assertions)]
+        super::error::check_gl_error(gl, "after query creation").map_err(QueryError::Unexpected)?;
+
+        Ok(Self {
+            ctx: Rc::downgrade(ctx),
+            id,
+        })
+    }
+
+    pub fn start(&self, ctx: &ContextShared) {
+        let gl = ctx.gl();
+
+        unsafe { gl.begin_query(glow::TIME_ELAPSED, self.id) };
+    }
+
+    pub fn stop(&self, ctx: &ContextShared) {
+        let gl = ctx.gl();
+
+        unsafe { gl.end_query(glow::TIME_ELAPSED) };
+    }
+
+    pub fn available(&self, ctx: &ContextShared) -> bool {
+        let gl = ctx.gl();
+
+        let available =
+            unsafe { gl.get_query_parameter_u32(self.id, glow::QUERY_RESULT_AVAILABLE) };
+
+        available != 0
+    }
+
+    pub fn get(&self, ctx: &ContextShared) -> Option<Duration> {
+        let gl = ctx.gl();
+
+        // TODO: Use `GPU_DISJOINT` constant from `glow` once available.
+        let disjoint = unsafe { gl.get_parameter_bool(0x8FBB) };
+
+        if self.available(ctx) && !disjoint {
+            // FIXME: The spec
+            // (<https://registry.khronos.org/webgl/extensions/EXT_disjoint_timer_query_webgl2/>)
+            // seems to say that the query result should be an `u64`, which
+            // makes sense, but I'm not sure how to retrieve an `u64` with
+            // `glow`.
+            let nanos = unsafe { gl.get_query_parameter_u32(self.id, glow::QUERY_RESULT) };
+
+            Some(Duration::from_nanos(nanos as u64))
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for DisjointTimerQuery {
+    fn drop(&mut self) {
+        if let Some(ctx) = self.ctx.upgrade() {
+            let gl = ctx.gl();
+
+            unsafe { gl.delete_query(self.id) };
+        }
+    }
+}

--- a/src/gl/raw/error.rs
+++ b/src/gl/raw/error.rs
@@ -76,6 +76,19 @@ pub enum VertexArrayError {
     Unexpected(String),
 }
 
+/// An error that occurred while creating a query.
+#[derive(Debug, Clone, Error)]
+pub enum QueryError {
+    #[error("could not create query object: {0}")]
+    ObjectCreation(String),
+
+    #[error("unsupported")]
+    Unsupported,
+
+    #[error("unexpected error while creating query: {0}")]
+    Unexpected(String),
+}
+
 /// An error that was detected by framebuffer completeness checks.
 #[derive(Debug, Clone, Error)]
 pub enum FramebufferIncompleteError {

--- a/src/gl/raw/texture.rs
+++ b/src/gl/raw/texture.rs
@@ -124,7 +124,7 @@ impl Texture2d {
                 height,
                 image.internal_format.to_format().to_gl(),
                 image.ty.to_gl(),
-                glow::PixelUnpackData::Slice(slice),
+                glow::PixelUnpackData::Slice(Some(slice)),
             )
         };
 
@@ -221,7 +221,7 @@ impl Texture2d {
                 height,
                 image.internal_format.to_format().to_gl(),
                 image.ty.to_gl(),
-                glow::PixelUnpackData::Slice(slice),
+                glow::PixelUnpackData::Slice(Some(slice)),
             )
         };
 

--- a/src/gl/raw/tracing.rs
+++ b/src/gl/raw/tracing.rs
@@ -1,0 +1,57 @@
+use std::{rc::Rc, time::Duration};
+
+use super::{context::ContextShared, disjoint_timer_query::DisjointTimerQuery};
+
+#[derive(Debug, Clone, Default)]
+pub struct TracingConfig {
+    // TODO: Extend `TracingConfig` with configuration, such as whether
+    // individual draw calls should be recorded.
+}
+
+#[derive(Debug, Clone)]
+pub struct FrameTrace {
+    pub duration: Duration,
+}
+
+pub(super) struct Tracing {
+    last_query: Option<DisjointTimerQuery>,
+    current_query: Option<DisjointTimerQuery>,
+}
+
+impl Tracing {
+    pub fn new(_: TracingConfig) -> Self {
+        Self {
+            last_query: None,
+            current_query: None,
+        }
+    }
+
+    pub fn start_frame(&mut self, ctx: &Rc<ContextShared>) -> Option<FrameTrace> {
+        let last_query = self.last_query.take_if(|query| query.available(ctx));
+
+        if self.last_query.is_none() {
+            assert!(
+                self.current_query.is_none(),
+                "`stop_frame()` must be called between successive calls of `start_frame()`",
+            );
+
+            self.current_query = DisjointTimerQuery::new(ctx).ok();
+
+            if let Some(query) = self.current_query.as_ref() {
+                query.start(ctx);
+            }
+        }
+
+        last_query
+            .and_then(|q| q.get(ctx))
+            .map(|duration| FrameTrace { duration })
+    }
+
+    pub fn stop_frame(&mut self, ctx: &ContextShared) {
+        if let Some(query) = self.current_query.as_ref() {
+            query.stop(ctx);
+
+            self.last_query = self.current_query.take();
+        }
+    }
+}

--- a/src/sl/program_def.rs
+++ b/src/sl/program_def.rs
@@ -29,7 +29,7 @@ pub struct UniformSamplerDef {
     pub texture_unit: usize,
 }
 
-/// VsInterface attribute definition.
+/// Vertex attribute definition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VertexAttributeDef {
     pub name: String,
@@ -61,7 +61,7 @@ impl InterpolationQualifier {
     }
 }
 
-/// VsInterface input definition.
+/// Vertex input definition.
 #[derive(Debug, Clone)]
 pub struct VertexBlockDef {
     pub attributes: Vec<VertexAttributeDef>,
@@ -80,12 +80,12 @@ pub struct ProgramDef {
     /// Samplers that the program needs.
     pub uniform_sampler_defs: Vec<UniformSamplerDef>,
 
-    /// VsInterface blocks that the program needs.
+    /// Vertex blocks that the program needs.
     pub vertex_block_defs: Vec<VertexBlockDef>,
 
-    /// VsInterface shader source code.
+    /// Vertex shader source code.
     pub vertex_shader_source: String,
 
-    /// FsInterface shader source code.
+    /// Fragment shader source code.
     pub fragment_shader_source: String,
 }


### PR DESCRIPTION
Adds support for measuring the frame time with `EXT_disjoint_timer_query_webgl2`. Also, updates the `glow` dependency to be based on git, since we need https://github.com/grovesNL/glow/pull/333 in order to check if a query result is available.

In theory, we could later extend this API to also support measuring the time of individual draw calls. This was my initial approach, but it did not result in reliable timings per draw call.

I've only been able to obtain useful timings when using Chrome with the GL backend for ANGLE.