### PR TITLE
Fix sampler params not respecting active texture unit

### DIFF
--- a/src/gl/raw/context.rs
+++ b/src/gl/raw/context.rs
@@ -250,14 +250,17 @@ impl ContextShared {
             bound_ids.extend(std::iter::repeat_n(None, diff));
         }
 
-        if bound_ids[unit] == id {
-            return;
-        }
-
         let unit_gl = texture_unit_gl(unit);
 
         unsafe {
             self.gl.active_texture(unit_gl);
+        }
+
+        if bound_ids[unit] == id {
+            return;
+        }
+
+        unsafe {
             self.gl.bind_texture(glow::TEXTURE_2D, id);
         }
 


### PR DESCRIPTION
This fixes sampler params (such as min/mag filters) for the case that the texture already had been bound in a previous draw call. In this case, the new sampler params were applied to the currently active texture unit (as in `glActiveTexture`) instead of the texture unit to which the texture was actually bound.

(In the future, it'd be nice to be able to add unit tests for catching such issues!)